### PR TITLE
Added code to refresh token from keycloak

### DIFF
--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -371,13 +371,14 @@ def getCurrentDue (summarize=False):
   g.cur.execute("select * from cleared_until")
   clearedUntil = max(g.cur.fetchone()[0], now)
   if summarize:
-    g.cur.execute("select count(*) from questions where next_scheduled < {clearedUntil} " +
-        "and cardbox is not null and difficulty != 4")
+    g.cur.execute(f"""SELECT COUNT(*) FROM questions
+                      WHERE next_scheduled < {clearedUntil}
+                      AND cardbox is not null AND difficulty != 4""")
     result["total"] = g.cur.fetchone()[0]
   else:
-    g.cur.execute("select cardbox, count(*) from questions " +
-      f"where next_scheduled < {clearedUntil} and cardbox is not null " +
-      "and difficulty != 4 group by cardbox")
+    g.cur.execute(f"""select cardbox, count(*) from questions
+                      where next_scheduled < {clearedUntil} and cardbox is not null
+                      and difficulty != 4 group by cardbox""")
     for row in g.cur.fetchall():
       result[row[0]] = row[1]
   return result
@@ -388,9 +389,10 @@ def getDueInRange(start, end):
   start and end are integers - unix epoch time
   '''
   result = { }
-  statement = ("select cardbox, count(*) from questions " +
-    "where next_scheduled between ? and ? and cardbox is not null group by cardbox")
-  g.cur.execute(statement, (start, end))
+  statement = f"""select cardbox, count(*) from questions
+                 where next_scheduled between {start} and {end} and cardbox is not null
+                 group by cardbox"""
+  g.cur.execute(statement)
   for row in g.cur.fetchall():
     result[row[0]] = row[1]
   return result
@@ -409,8 +411,8 @@ def getTotalByCardbox():
   Returns a dict: {cardbox: numberDue, cardbox: numberDue, etc }
   '''
   result = { }
-  command = ("select cardbox, count(*) from questions " +
-    "where next_scheduled is not null group by cardbox")
+  command = """select cardbox, count(*) from questions
+               where next_scheduled is not null group by cardbox"""
   g.cur.execute(command)
   for row in g.cur.fetchall():
     result[row[0]] = row[1]
@@ -428,8 +430,8 @@ def getTotalByLength():
         describing total words in cardbox broken out by length
   '''
   result = { }
-  command = ("select length(question), count(*) from questions " +
-    "where next_scheduled is not null group by length(question)")
+  command = """select length(question), count(*) from questions
+               where next_scheduled is not null group by length(question)"""
   g.cur.execute(command)
   for row in g.cur.fetchall():
     result[row[0]] = row[1]

--- a/front-end/html/js/cardboxStats.js
+++ b/front-end/html/js/cardboxStats.js
@@ -6,6 +6,9 @@ function showCardboxStats (value) {
     case 1: d = {due:true};break;
     case 2: d = {coverage:true};break;
   }
+  // once the chat service is written, if there's long polling, this refresh
+  // might be better suited there.
+  keycloak.updateToken(30).then(function() {
   $.ajax({type: "POST",
     url: "getCardboxStats",
     data: JSON.stringify(d),
@@ -23,6 +26,7 @@ function showCardboxStats (value) {
     console.log("Error getting cardbox stats, status = " + textStatus + " error: " + errorThrown);
     }
   });
+  }).catch(function() { console.log('Failed to refresh token'); });
 }
 function refreshCardboxInfo() {
   if ($('#dueTab').hasClass('active')){showCardboxStats(1)}


### PR DESCRIPTION
Attached the token refresh to the cardbox stats refresh since that runs in the background periodically. Eventually this can also be added to the chat long poll.

Also fixed some syntax errors in cardbox views.py and changed some long concatenated strings (SQL queries) to multiline strings/fstrings