### PR TITLE
Getting name from keycloak token

### DIFF
--- a/stats/stats/views.py
+++ b/stats/stats/views.py
@@ -45,6 +45,9 @@ def get_user():
   raw_token = request.headers["Authorization"]
   g.auth_token = jwt.decode(raw_token, public_key, audience="x-client", algorithms=['RS256'])
   g.uuid = g.auth_token["sub"]
+  g.photo = 'images/unknown_player.gif'
+  g.name = g.auth_token["name"]
+  g.handle = g.auth_token["preferred_username"]
   # headers to send to other services
   g.headers = {"Accept": "application/json", "Authorization": raw_token}
 


### PR DESCRIPTION
Not much to do here -- name was already available in the keycloak token, and photo will require a larger effort to add capability to keycloak / upload capability to xerafin front end ti update keycloak. This is captured in issue #98 