### PR TITLE
Lexicon Db init data moved to docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 front-end/html/images
 front-end/html/vendor
 front-end/localhost*
-lexicon-db/*.js
+lexicon-db
 lex_upd/prob
 lex_upd/json
 .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,11 +77,13 @@ services:
     depends_on:
       - keycloak
   lexicon-db:
-    image: lexicon-db:latest
+    image: mongo:latest
     environment:
       - MONGO_INITDB_ROOT_USERNAME
       - MONGO_INITDB_ROOT_PASSWORD
       - MONGO_INITDB_DATABASE
+    volumes:
+      - lexicon-data:/docker-entrypoint-initdb.d
   chat:
     image: x-chat:latest
     environment:
@@ -108,4 +110,6 @@ volumes:
   quizjson:
     external: true
   awards:
+    external: true
+  lexicon-data:
     external: true

--- a/lexicon-db/Dockerfile
+++ b/lexicon-db/Dockerfile
@@ -1,6 +1,0 @@
-#syntax=docker/dockerfile:1
-
-FROM mongo:latest
-
-COPY ./*.js /docker-entrypoint-initdb.d/
-RUN chmod -R 777 /docker-entrypoint-initdb.d/*.js


### PR DESCRIPTION
Data will be pulled in from a docker volume at runtime rather than layered in the container. Accordingly, lexicon-db can now be run as a vanilla mongo container, so remove its Dockerfile from the repo