### PR TITLE
Mongo DB memory optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ front-end/html/images
 front-end/html/vendor
 front-end/localhost*
 front-end/ssl
-lexicon-db
 lex_upd/prob
 lex_upd/json
 word-data

--- a/deploy/lexicon-db.container
+++ b/deploy/lexicon-db.container
@@ -6,7 +6,7 @@ PartOf=xerafin.target
 
 [Container]
 ContainerName=lexicon-db
-Image=mongo:latest
+Image=mongo:7-jammy
 
 EnvironmentFile=/home/spherulitic/xerafin3/config/mongo.env
 Environment=TCMALLOC_PERCPU_CACHE_ENABLED=false
@@ -15,12 +15,24 @@ Environment=TCMALLOC_PERCPU_CACHE_ENABLED=false
 Network=systemd-xerafin
 NetworkAlias=lexicon-db
 
+Tmpfs=/tmp:size=1M
+Volume=/var/lib/xerafin/mongod.conf:/etc/mongod.conf:ro
+Volume=/var/lib/xerafin/mongo-start.sh:/mongo-start.sh:ro
+
 # Ensure the correct runtime and conmon are used
 Environment=CONTAINER_CONMON=/usr/local/bin/conmon
 PodmanArgs=--runtime=/bin/runc --security-opt seccomp=unconfined
+PodmanArgs=--entrypoint=/mongo-start.sh
 
 [Service]
 Restart=always
+RestartSec=10
+
+# Hard memory limits
+MemoryHigh=220M
+MemoryMax=200M
+MemorySwapMax=20M
+
 LimitNPROC=64000
 LimitNOFILE=64000
 

--- a/deploy/lexicon-loader.container
+++ b/deploy/lexicon-loader.container
@@ -19,6 +19,7 @@ NetworkAlias=lexicon-loader
 
 # Stores words.csv
 Volume=/var/lib/xerafin/word-data:/data
+Tmpfs=/tmp:size=1M
 
 # Ensure the correct runtime and conmon are used
 Environment=CONTAINER_CONMON=/usr/local/bin/conmon

--- a/lexicon-db/mongo-start.sh
+++ b/lexicon-db/mongo-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Phase 1: Start mongod in read/write mode
+mongod --config /etc/mongod.conf
+# Small sleep to ensure it's fully up
+#sleep 2
+
+# Phase 2: Wait for the loader to signal completion
+# This assumes your loader creates a specific file when done
+while [ ! -f /tmp/lexicon_loaded ]; do
+    echo "Waiting for lexicon data load..."
+    sleep 1
+done
+
+# Phase 3: Shutdown and restart in read-only mode
+mongod --shutdown
+echo "Data load complete. Restarting in read-only mode."
+exec mongod --config /etc/mongod.conf --readOnly

--- a/lexicon-db/mongod.conf
+++ b/lexicon-db/mongod.conf
@@ -1,0 +1,23 @@
+
+systemLog:
+  destination: file
+  path: /proc/self/fd/1 # stdout
+  logAppend: true
+
+net:
+  bindIpAll: true
+  port: 27017
+
+# CORE OPTIMIZATION: Drastically limit WiredTiger Cache
+storage:
+  wiredTiger:
+    engineConfig:
+      cacheSizeGB: 0.25  # Minimum 256 MB cache
+
+# Disable profiling for a read-only database
+operationProfiling:
+  mode: off
+
+# Minimize oplog footprint
+replication:
+  oplogSizeMB: 64

--- a/lexicon-loader/Dockerfile
+++ b/lexicon-loader/Dockerfile
@@ -12,9 +12,6 @@ RUN useradd --no-create-home --shell /bin/false appuser
 # Copy loader script
 COPY loader.py .
 
-# Create data directory for mounted CSV
-#RUN mkdir -p /data
-
 USER appuser
 
 # Run the loader

--- a/lexicon-loader/loader.py
+++ b/lexicon-loader/loader.py
@@ -23,24 +23,13 @@ def load_words():
     print("Starting word data load...")
 
 
-    # Get MongoDB credentials from environment
     mongo_host = os.getenv('MONGO_URL', 'mongodb://mongo:27017')
-    mongo_user = os.getenv('MONGO_INITDB_ROOT_USERNAME', 'admin')
-    mongo_pass = os.getenv('MONGO_INITDB_ROOT_PASSWORD', 'xxx')
     mongo_db = os.getenv('MONGO_INITDB_DATABASE', 'word_db')
 
-    # Build connection string with authentication
-    if '@' in mongo_host:
-        # Already has credentials in URL
-        mongo_uri = mongo_host
-    else:
-        # Add credentials to URL
-        mongo_uri = f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host.split('://')[-1]}/"
+    print(f"Connecting to MongoDB: {mongo_host}")
 
-    print(f"Connecting to MongoDB: {mongo_uri.replace(mongo_pass, '***')}")
-
-    # MongoDB connection with authentication
-    client = MongoClient(mongo_uri)
+    # MongoDB connection without authentication
+    client = MongoClient(mongo_host)
     db = client[mongo_db]
 
     # Test connection
@@ -117,6 +106,13 @@ def load_words():
     db.words.create_index('word')
     db.words.create_index('alphagram')
     print("Indexes created")
+
+    # Create file to signal lexicon-db to restart readOnly
+    signal_file_path = "/tmp/lexicon_loaded"
+    with open(signal_file_path, 'w') as f:
+      f.write('ready')
+
+    print(f"Signal file created at {signal_file_path}")
 
 if __name__ == '__main__':
     load_words()

--- a/lexicon/lexicon/views.py
+++ b/lexicon/lexicon/views.py
@@ -70,10 +70,8 @@ def get_user():
   # headers to send to other services
   g.headers = {"Accept": "application/json", "Authorization": raw_token}
 
-  mongo_user = os.environ.get('MONGO_INITDB_ROOT_USERNAME')
-  mongo_pass = os.environ.get('MONGO_INITDB_ROOT_PASSWORD')
   mongo_db_name = os.environ.get('MONGO_INITDB_DATABASE')
-  g.client = MongoClient(f'mongodb://{mongo_user}:{mongo_pass}@lexicon-db:27017/')
+  g.client = MongoClient(f'mongodb://lexicon-db:27017/')
   g.words = g.client[mongo_db_name]['words']
   g.dawg_filename = '/app/data/csw24.dawg'
 


### PR DESCRIPTION
- restart Mongo in readOnly mode after lexicon-loader finishes
- run Mongo without authentication since now it's readOnly
- some other Mongo configs and memory limits to reduce footprint
- went from 250MB to 190MB in memory