### PR TITLE
Adding memory to lexicon-db container

### DIFF
--- a/deploy/lexicon-db.container
+++ b/deploy/lexicon-db.container
@@ -29,9 +29,9 @@ Restart=always
 RestartSec=10
 
 # Hard memory limits
-MemoryHigh=220M
-MemoryMax=200M
-MemorySwapMax=20M
+MemoryHigh=768M
+MemoryMax=1G
+MemorySwapMax=512M
 
 LimitNPROC=64000
 LimitNOFILE=64000

--- a/deploy/lexicon-loader.container
+++ b/deploy/lexicon-loader.container
@@ -5,7 +5,7 @@ After=xerafin-network.service
 Requires=xerafin-network.service
 After=lexicon-db.service
 Requires=lexicon-db.service
-PartOf=xerafin.target
+PartOf=lexicon-db.service
 
 [Container]
 ContainerName=lexicon-loader
@@ -31,4 +31,4 @@ Restart=on-failure
 RemainAfterExit=yes
 
 [Install]
-WantedBy=xerafin.target
+WantedBy=lexicon-db.service

--- a/lexicon-db/mongod.conf
+++ b/lexicon-db/mongod.conf
@@ -3,6 +3,8 @@ systemLog:
   destination: file
   path: /proc/self/fd/1 # stdout
   logAppend: true
+  quiet: true
+  verbosity: 0
 
 net:
   bindIpAll: true
@@ -12,7 +14,11 @@ net:
 storage:
   wiredTiger:
     engineConfig:
-      cacheSizeGB: 0.25  # Minimum 256 MB cache
+      cacheSizeGB: 0.5
+    collectionConfig:
+      blockCompressor: snappy
+    indexConfig:
+      prefixCompression: true
 
 # Disable profiling for a read-only database
 operationProfiling:


### PR DESCRIPTION
also fixed lexicon loader to start when lexicon-db restarts after crash