### PR TITLE
Fix SQL syntax errors in Metaranks rankings endpoint

### DIFF
--- a/stats/stats/views.py
+++ b/stats/stats/views.py
@@ -1407,9 +1407,9 @@ class Metaranks():
       rowDict["rank"] = rank
       self.rankData.append(rowDict)
     if not foundMe and self.userRank != -1:
-      self.query = f"""{queryStart} WHERE userid={g.uuid}
+      self.query = f"""{queryStart} WHERE userid='{g.uuid}'
                  {self.checkAnd()}{self.setDay()}{self.setMonth()}
-              GROUP BY userid, name{self.getTimeConditionsQuery()}
+              GROUP BY userid{self.getTimeConditionsQuery()}
               ORDER BY total DESC, date ASC
               LIMIT 1"""
       result = self.runQuery()
@@ -1429,9 +1429,9 @@ class Metaranks():
           else:
             self.rankData.append(rowDict)
     if not foundCurrent and self.currentRank != -1 and self.userRank != -1:
-      self.query = f"""{queryStart} WHERE userid={g.uuid}{self.checkAnd()}
+      self.query = f"""{queryStart} WHERE userid='{g.uuid}'{self.checkAnd()}
                        {self.setDay()}{self.setMonth()} AND {self.getDateFormatForQuery()}
-                GROUP BY userid, name{self.getTimeConditionsQuery()}
+                GROUP BY userid{self.getTimeConditionsQuery()}
                 ORDER BY total DESC, date ASC
                 LIMIT 1 """
       result = self.runQuery()


### PR DESCRIPTION
## Summary
Fixes two critical SQL errors in the Metaranks class that prevented the /getRankings endpoint from working with displayType=2 or 3.

## Changes Made
1. **Added proper UUID quoting**: Single quotes added around {g.uuid} in SQL queries to prevent MySQL from parsing UUIDs as expressions (e.g., '2e4931' being interpreted as scientific notation).
2. **Fixed GROUP BY clause**: Removed 'name' from GROUP BY clauses where it wasn't in the SELECT list, fixing 'Unknown column 'name' in 'group statement' error.

## Root Cause Analysis
- **First error**: UUIDs were inserted directly into SQL without quotes, causing MySQL to parse them as arithmetic expressions.
- **Second error**: GROUP BY clauses referenced 'name' column which wasn't selected in the query, violating SQL syntax rules.

## Testing
- Verified fix with payload: {"userid":-1,"view":"QA","pageNumber":1,"displayType":2,"timeframe":"daily","pageSize":10}
- Endpoint now returns rankings data without OperationalError exceptions.