### PR TITLE
[skip ci] Add last_answered to idx_user_quiz_completed for covering index

### DIFF
--- a/mysql/quiz.sql
+++ b/mysql/quiz.sql
@@ -91,7 +91,7 @@ CREATE TABLE `quiz_user_detail` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 CREATE INDEX idx_user_quiz_completed
-ON quiz_user_detail(user_id, quiz_id, completed);
+ON quiz_user_detail(user_id, quiz_id, completed, last_answered);
 
 --
 -- Dumping data for table `quiz_user_detail`


### PR DESCRIPTION
Added `last_answered` to the `idx_user_quiz_completed` index on `quiz_user_detail` to make it a covering index. The `GROUP BY ... HAVING MAX(last_answered)` query in `getQuizList` (searchType=completed) went from 7+ seconds to <1 second on the heaviest user (577K rows).