### PR TITLE
fix: remove lookahead > 0 guard in futureSweep() for cardbox 0

### DIFF
--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -645,11 +645,10 @@ def futureSweep():
   max_cb = g.cur.fetchone()[0]
   for cb in range(0, max_cb + 1):
     lookahead = getLookaheadDays(cb, g.schedVersion)
-    if lookahead > 0:
-      g.cur.execute(
-        "update questions set difficulty = 4 where cardbox = ? "
-        "and next_scheduled > ?+(3600*24*?) and difficulty in (0, -1)",
-        (cb, now, lookahead))
+    g.cur.execute(
+      "update questions set difficulty = 4 where cardbox = ? "
+      "and next_scheduled > ?+(3600*24*?) and difficulty in (0, -1)",
+      (cb, now, lookahead))
   g.con.commit()
   duration = time.time() - t_start
   if duration > 1.0:


### PR DESCRIPTION
Cardbox 0 has a lookahead of 0 days (must not work ahead), but the
`if lookahead > 0:` conditional caused the entire update to be skipped
for that cardbox. Cards in cardbox 0 with `next_scheduled > now` were
never marked difficulty = 4, making them incorrectly available to quiz.

The fix simply removes the guard so the SQL update runs for every
cardbox. When `lookahead = 0`, the offset `3600*24*0` evaluates to 0,
so the query correctly marks anything with `next_scheduled > now`
as difficulty = 4.

Fixes MR #543