### PR TITLE
Bump gunicorn to 22.0.0 for all Flask services

### DIFF
--- a/lexicon/requirements.txt
+++ b/lexicon/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==21.2.0
+gunicorn==22.0.0
 Flask>=2.0.2
 pyjwt[crypto]
 mysqlclient==2.1.0

--- a/login/requirements.txt
+++ b/login/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==21.2.0
+gunicorn==22.0.0
 Flask>=2.0.2
 pyjwt[crypto]
 bcrypt>=3.2.0

--- a/quiz/requirements.txt
+++ b/quiz/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==21.2.0
+gunicorn==22.0.0
 Flask>=2.0.2
 pyjwt[crypto]
 mysqlclient==2.1.0

--- a/sloth/requirements.txt
+++ b/sloth/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==21.2.0
+gunicorn==22.0.0
 Flask>=2.0.2
 pyjwt[crypto]
 mysqlclient==2.1.0

--- a/stats/requirements.txt
+++ b/stats/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==21.2.0
+gunicorn==22.0.0
 Flask>=2.0.2
 pyjwt[crypto]
 mysqlclient==2.1.0


### PR DESCRIPTION
## Summary
Upgrades gunicorn from 21.2.0 to 22.0.0 across services

## Services Updated
- `quiz/`
- `sloth/`  
- `stats/`
-  `lexicon/`
- `login/`
- `cardbox/` (previously)

## Security Impact
Addresses request smuggling vulnerabilities. Our nginx reverse proxy already terminates TLS, so internal HTTP traffic should be unaffected, but this upgrade adds an extra layer of protection.

## Related
Closes dependabot alerts for gunicorn