### PR TITLE
feat: implement user photo upload with server-side resizing

### DIFF
--- a/deploy/login.container
+++ b/deploy/login.container
@@ -17,6 +17,9 @@ EnvironmentFile=%h/.config/xerafin3/mysql.env
 Network=systemd-xerafin
 NetworkAlias=login
 
+# Volume for user photo uploads
+Volume=/var/lib/xerafin/user-photos:/app/user-photos:rw,z
+
 # Ensure the correct runtime and conmon are used
 Environment=CONTAINER_CONMON=/usr/local/bin/conmon
 PodmanArgs=--runtime=/home/linuxbrew/.linuxbrew/bin/crun

--- a/frontend/html/js/userPrefs.js
+++ b/frontend/html/js/userPrefs.js
@@ -328,16 +328,27 @@ function uploadProfileImage() {
   $("#profileButton").val("Uploading...");
   var file = document.getElementById('profileFile').files[0];
   var formdata = new FormData();
-  formdata.append("userid", userid);
   formdata.append("file", file);
-  $.ajax({ type: 'POST',
-     url: 'uploadProfileImage.py',
-          data: formdata,
-          processData: false,
-          contentType: false,
-          success: function(response, responseStatus) {
-                      $('#profileButton').prop('disabled', false);
-                      $('#profileButton').val('Success');
-                      gFloatingAlert("profileAlert",3000,"Profile Image", "Profile Image Uploaded!",500);
-          }});
+  fetch("uploadProfileImage", {
+     method: 'POST',
+     headers: {'Authorization': keycloak.token},
+     body: formdata
+  })
+  .then(function(response) {
+    if (!response.ok) {
+      throw new Error('Upload failed');
+    }
+    return response.json();
+  })
+  .then(function(response) {
+    $('#profileButton').prop('disabled', false);
+    $('#profileButton').val('Success');
+    gFloatingAlert("profileAlert",3000,"Profile Image", "Profile Image Uploaded!",500);
+  })
+  .catch(function(error) {
+    $('#profileButton').prop('disabled', false);
+    $('#profileButton').val('Error');
+    gFloatingAlert("profileAlert",3000,"Profile Image", "Upload failed.",500);
+    console.log("Profile image upload error: " + error);
+  });
 }

--- a/frontend/locations.conf
+++ b/frontend/locations.conf
@@ -32,6 +32,11 @@
                 proxy_pass http://login:5000/getLoggedInUsers;
         }
 
+        location /uploadProfileImage {
+                client_max_body_size 5M;
+                proxy_pass http://login:5000/uploadProfileImage;
+        }
+
         # x-stats service endpoints
         #
         location /getAllTimeStats {

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -11,6 +11,8 @@ RUN pip3 install -r requirements.txt
 RUN useradd --no-create-home --shell /bin/false appuser
 
 COPY . .
+RUN mkdir -p /app/user-photos && chown -R appuser:appuser /app/user-photos
+
 USER appuser
 
 CMD [ "gunicorn", "--bind", "0.0.0.0:5000", "login:app"]

--- a/login/login/views.py
+++ b/login/login/views.py
@@ -119,12 +119,15 @@ def createCardboxPrefs():
   return jsonify(resp)
 
 @app.route('/setCardboxPrefs', methods=['POST'])
-def setCardboxPrefs():
-  ''' Take cardbox prefs from the client and update keycloak attributes '''
+def setCardboxPrefs(params=None):
+  ''' Take cardbox prefs from the client and update keycloak attributes.
+      Can be called internally with a params dict instead of reading from request. '''
+  if params is None:
+    params = request.get_json(force=True)
+
   keycloak_admin = getKeycloakAdmin()
   user = keycloak_admin.get_user(g.uuid)
 
-  params = request.get_json(force=True)
   att = user['attributes']
   if 'cb0max' in params:
     att['cb0max'] = [ params.get('cb0max') ]
@@ -138,9 +141,51 @@ def setCardboxPrefs():
     att['schedVersion'] = [ params.get('schedVersion') ]
   if 'countryId' in params:
     att['countryId'] = [ params.get('countryId') ]
+  if 'photo' in params:
+    att['photo'] = [ params.get('photo') ]
 
   resp = keycloak_admin.update_user(g.uuid, user)
   return jsonify(resp)
+
+@app.route('/uploadProfileImage', methods=['POST'])
+def uploadProfileImage():
+  ''' Accept a photo upload, resize to 128x128 padded on black, save to disk,
+      and update Keycloak attribute. '''
+  from PIL import Image as PILImage
+
+  if 'file' not in request.files:
+    return jsonify({'error': 'No file provided'}), 400
+
+  file = request.files['file']
+  if file.filename == '':
+    return jsonify({'error': 'Empty filename'}), 400
+
+  # Determine extension from original filename
+  ext = os.path.splitext(file.filename)[1].lower()
+  if ext not in ('.png', '.jpg', '.jpeg', '.gif'):
+    ext = '.png'
+
+  # Build filename: <user_uuid>.<ext>
+  filename = f'{g.uuid}{ext}'
+  upload_dir = '/app/user-photos'
+  os.makedirs(upload_dir, exist_ok=True)
+  save_path = os.path.join(upload_dir, filename)
+
+  # Open, resize to 128x128 keeping aspect ratio, pad with black center
+  img = PILImage.open(file)
+  img = img.convert('RGB')
+  img.thumbnail((128, 128), PILImage.LANCZOS)
+  canvas = PILImage.new('RGB', (128, 128), (0, 0, 0))
+  x_offset = (128 - img.width) // 2
+  y_offset = (128 - img.height) // 2
+  canvas.paste(img, (x_offset, y_offset))
+  canvas.save(save_path)
+
+  # Update Keycloak attribute via setCardboxPrefs
+  photo_value = f'images/users/{filename}'
+  setCardboxPrefs({'photo': photo_value})
+
+  return jsonify({'status': 'success', 'photo': photo_value})
 
 @app.route("/getCountries", methods=['GET', 'POST'])
 def countries():

--- a/login/requirements.txt
+++ b/login/requirements.txt
@@ -7,4 +7,5 @@ pre-commit
 requests
 python-keycloak>=5.8.1
 python-jose
+Pillow>=10.0.0
 urllib3


### PR DESCRIPTION

- Replace deprecated uploadProfileImage.py frontend call with new /uploadProfileImage endpoint on login service
- Add Pillow-based 128x128 image resizing with black canvas padding
- Store photos as <uuid>.<ext> in shared volume, served by nginx at /images/users/
- Update Keycloak 'photo' attribute internally via setCardboxPrefs
- Add nginx location with 5MB limit
- Mount user-photos volume into login container
- Add Pillow to requirements.txt
- Pre-create /app/user-photos with appuser ownership in Dockerfile
