### PR TITLE
feat(cardbox): enable WAL mode for user cardbox SQLite databases

### DIFF
--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -144,6 +144,13 @@ def get_user():
     g.headers = {"Accept": "application/json", "Authorization": raw_token}
 
     g.con = lite.connect(getDBFile())
+    # WAL allows readers to run concurrently with a writer and makes commits
+    # cheaper (single sequential append + fsync to the -wal file).
+    # synchronous=NORMAL is crash-safe in WAL mode; busy_timeout keeps a second
+    # writer from failing immediately with "database is locked".
+    g.con.execute("PRAGMA journal_mode=WAL")
+    g.con.execute("PRAGMA busy_timeout=5000")
+    g.con.execute("PRAGMA synchronous=NORMAL")
     g.cur = g.con.cursor()
     # Debug for slow queries
     g.start_time = time.time()
@@ -459,6 +466,9 @@ def uploadCardbox():
   filename = getTempFile()
   file.save(filename)
   if checkCardboxDatabase():
+    # Flush any WAL data into the live .db before replacing the file, so a
+    # stale -wal file can't be replayed onto the newly uploaded cardbox.
+    g.con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     shutil.move(filename, getDBFile())
     result = {"status": "success"}
     reset_start_score()
@@ -476,6 +486,9 @@ def initCardbox():
 @app.route('/downloadCardbox', methods=['GET', 'POST'])
 def downloadCardbox():
   ''' Presents the user's cardbox for download '''
+  # Flush committed WAL data into the main .db so the raw file served includes
+  # everything the user has committed, not just what's been checkpointed so far.
+  g.con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
   filename = getDBFile()
   return send_file(filename, as_attachment=True, download_name="cardbox.db")
 

--- a/cardbox/cardbox/xerafinLib.py
+++ b/cardbox/cardbox/xerafinLib.py
@@ -36,10 +36,24 @@ def getDBFile(userid):
   dbFile = os.path.join(sys.path[0], CARDBOX_DB_PATH, userid + ".db")
   return dbFile
 
-def getDBCur(userid):
-  ''' Return a sqlite DB connection to the user's cardbox
+def getDBCon(userid=None, dbFile=None):
+  ''' Open a sqlite connection to a user's cardbox with WAL, busy timeout,
+      and synchronous=NORMAL pragmas applied.
+      WAL lets readers run concurrently with a writer and makes commits
+      cheaper (single sequential append + fsync to the -wal file).
   '''
-  return lite.connect(getDBFile(userid)).cursor()
+  if dbFile is None:
+    dbFile = getDBFile(userid)
+  con = lite.connect(dbFile)
+  con.execute("PRAGMA journal_mode=WAL")
+  con.execute("PRAGMA busy_timeout=5000")
+  con.execute("PRAGMA synchronous=NORMAL")
+  return con
+
+def getDBCur(userid):
+  ''' Return a sqlite DB cursor to the user's cardbox
+  '''
+  return getDBCon(userid).cursor()
 
 def getAllPrefs(userid):
   ''' Returns a dict with all user preferences
@@ -155,7 +169,7 @@ def getDueByDay(userid, cardbox = None):
   '''
   result = { }
   estart = datetime(1970, 1, 1, 0, 0) # First date of the Epoch
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     statement = ("select next_scheduled/86400, count(*) from questions ? " +
       "group by next_scheduled/86400")
@@ -176,7 +190,7 @@ def getTotalByLength(userid):
         describing total words in cardbox broken out by length
   '''
   result = { }
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     command = ("select length(question), count(*) from questions " +
       "where next_scheduled is not null group by length(question)")
@@ -222,7 +236,7 @@ def correct (alpha, userid, nextCardbox=None, quizid=-1) :
   if quizid == -1:
     now = int(time.time())
     schedVersion = getPrefs("schedVersion", userid)
-    with lite.connect(getDBFile(userid)) as con :
+    with getDBCon(userid) as con :
       cur = con.cursor()
       if nextCardbox is None:
         cur.execute(f"select cardbox from questions where question='{alpha}'")
@@ -245,7 +259,7 @@ def wrong (alpha, userid, quizid=-1) :
   '''
   if quizid == -1:
     schedVersion = getPrefs("schedVersion", userid)
-    with lite.connect(getDBFile(userid)) as con:
+    with getDBCon(userid) as con:
       cur = con.cursor()
       if schedVersion in (1, 2, 3):
         cur.execute(f"select cardbox from questions where question='{alpha}'")
@@ -272,7 +286,7 @@ def skipWord (alpha, userid) :
   # twelve hour delay
   SKIP_DELAY = 3600*12 # pylint: disable=invalid-name
   now = int(time.time())
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     command = ("update questions set next_scheduled = max(next_scheduled + ?, ?), " +
       "difficulty=4 where question = ?")
@@ -318,7 +332,7 @@ def addWords (numWords, userid, cur) :
 def getNextAddedCount(userid):
   ''' Returns number of items in next_added
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select count(*) from next_added")
     return cur.fetchone()[0]
@@ -342,7 +356,7 @@ def getAllNextAdded(userid):
   '''
 
   result = [ ]
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select question, timeStamp from next_added order by timestamp")
     for row in cur.fetchone():
@@ -395,7 +409,7 @@ def isAlphagramValid(alpha, userid):
 def ghostbuster(userid):
   ''' Removes questions that have no answer
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select question from questions")
     rows = cur.fetchall()
@@ -484,7 +498,7 @@ def getBingoFromCardbox (userid, cardbox=0):
   """
   Returns a list of alphagrams that are due, length 7 or greater
   """
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select question from questions " +
       "where cardbox is not null and length(question) >= 7 and difficulty in (-1,0,2) " +
@@ -536,7 +550,7 @@ def getQuestions (numNeeded, userid, cardbox, questionLength=None, isCardbox=Tru
     else:
       diffToGet = (-1,)
       dFormat = "?"
-    with lite.connect(getDBFile(userid)) as qCon:
+    with getDBCon(userid) as qCon:
       cur = qCon.cursor()
       getCardsQry = ("select question from questions " +
         f"where difficulty in ({dFormat}) and next_scheduled is not null " +
@@ -572,7 +586,7 @@ def getQuestions (numNeeded, userid, cardbox, questionLength=None, isCardbox=Tru
 ##  numAvailable = 0
 ##  futureSweep()
 ##
-##  with lite.connect(getDBFile(userid)) as con:
+##  with getDBCon(userid) as con:
 ##    cur = con.cursor()
 ##
 ##    cur.execute("update questions set difficulty = -1
@@ -623,7 +637,7 @@ def getAuxInfo (alpha, userid):
   Returns dict: {"cardbox": x, "nextScheduled": x, "correct": x,
       incorrect: x, difficulty: x }
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute('select cardbox, next_scheduled, correct, incorrect, difficulty ' +
                 f'from questions where question = "{alpha}" ' +
@@ -686,7 +700,7 @@ def checkCardboxDatabase (userid):
   '''
   now = int(time.time())
   try:
-    with lite.connect(getDBFile(userid)) as con:
+    with getDBCon(userid) as con:
       cur = con.cursor()
       cur.execute("select name from sqlite_master where type='table'")
       tables = [x[0] for x in cur.fetchall()]
@@ -746,7 +760,7 @@ def checkOut (alpha, userid, lock, isCardbox=True, quizid=-1) :
     else:
       difficulty = 0
 
-    with lite.connect(getDBFile(userid)) as con:
+    with getDBCon(userid) as con:
       cur = con.cursor()
       cur.execute("update questions set difficulty = ? where question = ?", (difficulty, alpha))
   else:
@@ -759,7 +773,7 @@ def isInCardbox(alpha, userid) :
   '''Takes in an alphagram and userid
   Returns boolean indicating if alphagram is in the user's cardbox '''
 
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select count(*) from questions " +
                 "where question = ? and next_scheduled is not null", (alpha,))

--- a/xerafinLib/xerafinLib.py
+++ b/xerafinLib/xerafinLib.py
@@ -44,10 +44,24 @@ def getDBFile(userid):
   dbFile = os.path.join(sys.path[0], CARDBOX_DB_PATH, userid + ".db")
   return dbFile
 
-def getDBCur(userid):
-  ''' Return a sqlite DB connection to the user's cardbox
+def getDBCon(userid=None, dbFile=None):
+  ''' Open a sqlite connection to a user's cardbox with WAL, busy timeout,
+      and synchronous=NORMAL pragmas applied.
+      WAL lets readers run concurrently with a writer and makes commits
+      cheaper (single sequential append + fsync to the -wal file).
   '''
-  return lite.connect(getDBFile(userid)).cursor()
+  if dbFile is None:
+    dbFile = getDBFile(userid)
+  con = lite.connect(dbFile)
+  con.execute("PRAGMA journal_mode=WAL")
+  con.execute("PRAGMA busy_timeout=5000")
+  con.execute("PRAGMA synchronous=NORMAL")
+  return con
+
+def getDBCur(userid):
+  ''' Return a sqlite DB cursor to the user's cardbox
+  '''
+  return getDBCon(userid).cursor()
 
 def getAllPrefs(userid):
   ''' Returns a dict with all user preferences
@@ -157,7 +171,7 @@ def getFromStudyOrder (numNeeded, userid, cur):
 def getCardboxScore (userid):
   ''' Returns cardbox score
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select sum(cardbox) from questions where next_scheduled is not null")
     score = cur.fetchone()[0]
@@ -170,7 +184,7 @@ def getEarliestDueDate(userid):
       If this date is in the future, return cleared_until instead
   '''
   now = int(time.time())
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     command = ("select min(next_scheduled) from questions " +
       "where next_scheduled is not null and next_Scheduled > 0 and difficulty != 4")
@@ -190,7 +204,7 @@ def getCurrentDue (userid, summarize=False):
   '''
   now = int(time.time())
   result = { }
-  with lite.connect(getDBFile(userid)) as con :
+  with getDBCon(userid) as con :
     cur = con.cursor()
 # What's due excludes difficulty 4 so let's make that accurate
     futureSweep(cur)
@@ -214,7 +228,7 @@ def getDueInRange(userid, start, end):
   start and end are integers - unix epoch time
   '''
   result = { }
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     statement = ("select cardbox, count(*) from questions " +
       "where next_scheduled between ? and ? and cardbox is not null group by cardbox")
@@ -231,7 +245,7 @@ def getDueByDay(userid, cardbox = None):
   '''
   result = { }
   estart = datetime(1970, 1, 1, 0, 0) # First date of the Epoch
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     statement = ("select next_scheduled/86400, count(*) from questions ? " +
       "group by next_scheduled/86400")
@@ -250,7 +264,7 @@ def getTotal(userid):
   '''
   Returns an integer, number of cards in all cardboxes
   '''
-  with lite.connect(getDBFile(userid)) as con :
+  with getDBCon(userid) as con :
     cur = con.cursor()
     command = "select count(*) from questions where next_scheduled is not null"
     cur.execute(command)
@@ -262,7 +276,7 @@ def getTotalByCardbox(userid):
   Returns a dict: {cardbox: numberDue, cardbox: numberDue, etc }
   '''
   result = { }
-  with lite.connect(getDBFile(userid)) as con :
+  with getDBCon(userid) as con :
     cur = con.cursor()
     command = ("select cardbox, count(*) from questions " +
       "where next_scheduled is not null group by cardbox")
@@ -277,7 +291,7 @@ def getTotalByLength(userid):
         describing total words in cardbox broken out by length
   '''
   result = { }
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     command = ("select length(question), count(*) from questions " +
       "where next_scheduled is not null group by length(question)")
@@ -323,7 +337,7 @@ def correct (alpha, userid, nextCardbox=None, quizid=-1) :
   if quizid == -1:
     now = int(time.time())
     schedVersion = getPrefs("schedVersion", userid)
-    with lite.connect(getDBFile(userid)) as con :
+    with getDBCon(userid) as con :
       cur = con.cursor()
       if nextCardbox is None:
         cur.execute(f"select cardbox from questions where question='{alpha}'")
@@ -346,7 +360,7 @@ def wrong (alpha, userid, quizid=-1) :
   '''
   if quizid == -1:
     schedVersion = getPrefs("schedVersion", userid)
-    with lite.connect(getDBFile(userid)) as con:
+    with getDBCon(userid) as con:
       cur = con.cursor()
       if schedVersion in (1, 2, 3):
         cur.execute(f"select cardbox from questions where question='{alpha}'")
@@ -373,7 +387,7 @@ def skipWord (alpha, userid) :
   # twelve hour delay
   SKIP_DELAY = 3600*12 # pylint: disable=invalid-name
   now = int(time.time())
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     command = ("update questions set next_scheduled = max(next_scheduled + ?, ?), " +
       "difficulty=4 where question = ?")
@@ -419,7 +433,7 @@ def addWords (numWords, userid, cur) :
 def getNextAddedCount(userid):
   ''' Returns number of items in next_added
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select count(*) from next_added")
     return cur.fetchone()[0]
@@ -443,7 +457,7 @@ def getAllNextAdded(userid):
   '''
 
   result = [ ]
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select question, timeStamp from next_added order by timestamp")
     for row in cur.fetchone():
@@ -496,7 +510,7 @@ def isAlphagramValid(alpha, userid):
 def ghostbuster(userid):
   ''' Removes questions that have no answer
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select question from questions")
     rows = cur.fetchall()
@@ -602,7 +616,7 @@ def newQuiz (userid):
   '''
   now = int(time.time())
   checkCardboxDatabase(userid)
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     dbClean(cur)
     cur.execute("select * from cleared_until")
@@ -616,7 +630,7 @@ def getBingoFromCardbox (userid, cardbox=0):
   """
   Returns a list of alphagrams that are due, length 7 or greater
   """
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select question from questions " +
       "where cardbox is not null and length(question) >= 7 and difficulty in (-1,0,2) " +
@@ -668,7 +682,7 @@ def getQuestions (numNeeded, userid, cardbox, questionLength=None, isCardbox=Tru
     else:
       diffToGet = (-1,)
       dFormat = "?"
-    with lite.connect(getDBFile(userid)) as qCon:
+    with getDBCon(userid) as qCon:
       cur = qCon.cursor()
       getCardsQry = ("select question from questions " +
         f"where difficulty in ({dFormat}) and next_scheduled is not null " +
@@ -704,7 +718,7 @@ def getQuestions (numNeeded, userid, cardbox, questionLength=None, isCardbox=Tru
 ##  numAvailable = 0
 ##  futureSweep()
 ##
-##  with lite.connect(getDBFile(userid)) as con:
+##  with getDBCon(userid) as con:
 ##    cur = con.cursor()
 ##
 ##    cur.execute("update questions set difficulty = -1
@@ -755,7 +769,7 @@ def getAuxInfo (alpha, userid):
   Returns dict: {"cardbox": x, "nextScheduled": x, "correct": x,
       incorrect: x, difficulty: x }
   '''
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute('select cardbox, next_scheduled, correct, incorrect, difficulty ' +
                 f'from questions where question = "{alpha}" ' +
@@ -818,7 +832,7 @@ def checkCardboxDatabase (userid):
   '''
   now = int(time.time())
   try:
-    with lite.connect(getDBFile(userid)) as con:
+    with getDBCon(userid) as con:
       cur = con.cursor()
       cur.execute("select name from sqlite_master where type='table'")
       tables = [x[0] for x in cur.fetchall()]
@@ -878,7 +892,7 @@ def checkOut (alpha, userid, lock, isCardbox=True, quizid=-1) :
     else:
       difficulty = 0
 
-    with lite.connect(getDBFile(userid)) as con:
+    with getDBCon(userid) as con:
       cur = con.cursor()
       cur.execute("update questions set difficulty = ? where question = ?", (difficulty, alpha))
   else:
@@ -891,7 +905,7 @@ def isInCardbox(alpha, userid) :
   '''Takes in an alphagram and userid
   Returns boolean indicating if alphagram is in the user's cardbox '''
 
-  with lite.connect(getDBFile(userid)) as con:
+  with getDBCon(userid) as con:
     cur = con.cursor()
     cur.execute("select count(*) from questions " +
                 "where question = ? and next_scheduled is not null", (alpha,))


### PR DESCRIPTION
## Summary

Enables SQLite **write-ahead logging (WAL)** for user cardbox databases to address slow operations when reads and writes are issued in near-simultaneous requests.

- **New `getDBCon()` helper** in `cardbox/cardbox/xerafinLib.py` (mirrored in top-level `xerafinLib/xerafinLib.py`) applies `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`; all per-function `lite.connect()` call sites route through it.
- **`views.py` `before_request`** applies the same pragmas to the per-request `g.con`.
- **`uploadCardbox` / `downloadCardbox`** run `wal_checkpoint(TRUNCATE)` before touching the raw .db file, so a stale `-wal` can't replay onto an uploaded cardbox and downloads always include committed data.

WAL persists in each .db header, so uploaded Zyzzyva cardboxes are auto-converted on first access.

## Verification
- Functional test on `python:3.11-slim`: mode flips to `wal` and persists, reader during in-flight writer never hits `database is locked`, sidecars cleaned up, `checkpoint(TRUNCATE)` flushes to raw file.
- Manual smoke test of the full local stack passed.
- Pylint: message-identical to HEAD (environment lacks runtime deps, so the local hook fails on all files; repo baseline 9.77).