### PR TITLE
fix: refresh isMobile() check for devices requesting desktop site (599)

### DIFF
--- a/frontend/html/index.htm
+++ b/frontend/html/index.htm
@@ -168,8 +168,8 @@ function debounce(fn, delay) {
 function isMobileTwo() {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
   }
+  localStorage.deviceType = Number(isMobileTwo());
   function isMobile(){
-    if (typeof localStorage.deviceType==='undefined') {localStorage.deviceType = Number(isMobileTwo());}
     return (Number(localStorage.deviceType)===1);
   }
 


### PR DESCRIPTION
Fixes #599

## Summary
`isMobile()` cached its UA-regex result in `localStorage.deviceType` on first call and never refreshed it, so an iPad/phone toggling "request desktop site" (which changes `navigator.userAgent` to a desktop string) kept getting mobile behavior — including suppressed focus in the basic quiz answer box (the phone-keyboard avoidance logic).

## Change
`frontend/html/index.htm`: run the UA regex once per page load and overwrite the cache before any `isMobile()` call; `isMobile()` now just reads the cached value.

## Testing
Smoke-tested (per @user). Behavior change: a page load with a desktop UA now registers as non-mobile.