### PR TITLE
Cache-bust frontend JS (604)

### DIFF
--- a/frontend/html/index.htm
+++ b/frontend/html/index.htm
@@ -11,7 +11,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
   <script async src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
   <script src="https://ko-fi.com/widgets/widget_2.js"></script>
-  <script src="js/core.xScripts.js?x=1"></script>
+  <script src="js/core.xScripts.js?v=20260803"></script>
   <!-- Bootstrap code -->
   <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.css">
   <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap-theme.min.css">
@@ -23,8 +23,8 @@
   <link href="styles/paginStyles.css?v=1" rel="stylesheet" type="text/css" />
   <link href="styles/prefs.css?v=1" rel="stylesheet" type="text/css" />
   <link href="styles/overview.css?v=1" rel="stylesheet" type="text/css" />
-  <script src="js/proto.js"></script>
-  <script src="js/util.general.js"></script>
+  <script src="js/proto.js?v=20260803"></script>
+  <script src="js/util.general.js?v=20260803"></script>
 <script>
 // Run this BEFORE initKeycloak
 function clearOIDCState() {

--- a/frontend/html/js/core.xScripts.js
+++ b/frontend/html/js/core.xScripts.js
@@ -1,9 +1,13 @@
+// Bump on every release so browsers fetch fresh copies of deployed scripts
+// and the script config instead of serving stale caches.
+const XERAFIN_JS_VERSION = '20260803';
+
 XScripts.prototype = {
     constructor: XScripts,
     loadScript: function(d){
       let self=this;
       return new Promise(resolve =>  {
-        let path = 'js/' + d.title + ".js";
+        let path = 'js/' + d.title + ".js?v=" + XERAFIN_JS_VERSION;
         $.getScript(path)
         .then(
           function(data,textStatus){
@@ -52,7 +56,7 @@ XScripts.prototype = {
         if (this.logged) {
             xerafin.error.log.add("Downloading Required Scripts","HTTP");
         }
-        $.get(this.path, async function(response) {
+        $.get(this.path + '?v=' + XERAFIN_JS_VERSION, async function(response) {
 //        $.ajax({
 //          method: "POST",
 //          url: this.path,

--- a/frontend/locations.conf
+++ b/frontend/locations.conf
@@ -5,6 +5,9 @@
 		# as directory, then fall back to displaying a 404.
                 root /usr/share/nginx/html;
                 index index.htm index.html;
+                # Always revalidate static assets (js, json config, html) so
+                # newly deployed files are served instead of stale caches.
+                add_header Cache-Control "no-cache";
 		try_files $uri $uri/ =404;
 	}
 


### PR DESCRIPTION
## Summary

Prod broke after #602 was deployed: users with heuristically-cached JS ran a stale `util.general.js` (no `alphaSortMethod`) alongside the new config/quiz.js (basicQuiz.js removed), producing `alphaSortMethod is not defined` when fetching a quiz question. The frontend served JS/JSON with no `Cache-Control`, so browsers cached scripts with no revalidation. This adds a cache strategy so every deploy serves fresh scripts and fresh script-config.

## Changes

- **locations.conf**: `Cache-Control: no-cache` on static responses (index.htm, /js/*, /JSON/config/configClient.xerf). Revalidation on every load; applied in both dev and prod.
- **core.xScripts.js**: added `XERAFIN_JS_VERSION` constant; appended `?v=` to every dynamic script load and to the configClient.xerf fetch, so warm-cache browsers fetch fresh URLs.
- **index.htm**: bumped static tags to `?v=20260803` (core.xScripts.js, proto.js, util.general.js).

## Release convention

Bump `XERAFIN_JS_VERSION` and the three index.htm tags together on each release. If forgotten, nginx `no-cache` still forces revalidation (degrades safely).

## Verification

- [x] nginx `add_header` syntax validated (`nginx -t`)
- [x] JS balance check
- [x] Local testing (in progress)