### PR TITLE
feat(cardbox): List of Shame option to add new words to cardbox 0 (597)

### DIFF
--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -549,9 +549,11 @@ def downloadCardbox():
 def shameList():
   ''' The List of Shame: Takes in a list of alphagrams.
         Any alphagrams in cardbox are marked wrong.
-        Any alphagrams not in cardbox are queued to be added. '''
+        Any alphagrams not in cardbox are queued to be added, unless
+        addToCardbox is set, in which case they go straight to cardbox 0. '''
   params = request.get_json(force=True) # returns dict
   questions = params.get('questions', [ ])
+  addToCardbox = params.get('addToCardbox', False)
   url = 'http://lexicon:5000/returnValidAlphas'
   resp = requests.post(url, headers=g.headers, json={'alphas': questions})
   validAlphas = resp.json()
@@ -561,10 +563,13 @@ def shameList():
 
     if isInCardbox(alpha):
       wrong(alpha)
+    elif addToCardbox:
+      _add_word(alpha)
     else:
       alphasToAdd.append(alpha)
 
-  insertIntoNextAdded(alphasToAdd)
+  if not addToCardbox:
+    insertIntoNextAdded(alphasToAdd)
 # let's deal with this later
 #  return jsonify(getCardboxStats())
   return jsonify({"status": "success"})

--- a/frontend/html/js/cardboxStats.js
+++ b/frontend/html/js/cardboxStats.js
@@ -224,9 +224,15 @@ function manageDatabaseFile(){
 function manageListOfShame(){
   gCreateElemArray([
       ['a0','div','prefContent','shameDiv','manageParams',''],
-      ['a1','div','shameDesc highlightRow','shameDesc','a0','Enter a list of alphagrams or words.<br>Each of these will be reset to cardbox 0 or queued to be added to your cardbox.'],
+      ['a1','div','shameDesc highlightRow','shameDesc','a0','Enter a list of alphagrams or words.<br>Each of these will be reset to cardbox 0. New words can be queued for later or added to cardbox 0 immediately.'],
       ['a2','div','shameWrap','shameWrap','a0',''],
       ['a2a','textArea','shameList','shameList','a2',''],
+      ['a2b','div','shameModeWrap','shameModeWrap','a2',''],
+      ['a2b1','input','','shameModeQueue','a2b',''],
+      ['a2b1a','label','shameCbLabel','shameModeQueueLabel','a2b','Queue new words for later'],
+      ['a2b2','div','','shameModeSpacer','a2b',''],
+      ['a2b3','input','','shameModeAdd','a2b',''],
+      ['a2b3a','label','shameCbLabel','shameModeAddLabel','a2b','Add new words to Cardbox 0 immediately'],
       ['a3','div','','prefBtnShameWrap','a0',''],
       ['a3a','button','btn btn-default btnPrefs shameButton','shameButton','a3','Submit']
     ]);
@@ -235,6 +241,17 @@ function manageListOfShame(){
     $('#shameList').prop('cols',40);
     $('#shameList').prop('rows',10);
     $('#shameList').css('textTransform','uppercase');
+    $('#shameModeQueue').prop('type','radio');
+    $('#shameModeQueue').prop('name','shameMode');
+    $('#shameModeQueue').prop('value','0');
+    $('#shameModeQueue').prop('checked',true);
+    $('#shameModeQueueLabel').prop('for','shameModeQueue');
+    $('#shameModeAdd').prop('type','radio');
+    $('#shameModeAdd').prop('name','shameMode');
+    $('#shameModeAdd').prop('value','1');
+    $('#shameModeAddLabel').prop('for','shameModeAdd');
+    $('#shameModeWrap').css({'text-align':'left','margin':'5px','font-family':'Montserrat, sans-serif'});
+    $('#shameModeSpacer').css({'display':'inline-block','width':'15px'});
     $('#shameButton').click(function() { submitShameList($("#shameList").val()); });
 }
 function generateCardboxSettings(){
@@ -427,12 +444,13 @@ function submitShameList(text) {
   var shameArr = text.replace(/[\r\n]+/g, " ").split(" ").filter((val) => val);
   var newArr = shameArr.map(function(x, i, arr) { return toAlpha(x.toUpperCase().replace(/[^A-Z]/g, ""));});
   shameArr = Array.from( new Set (newArr)); // remove duplicates
+  var addToCardbox = $('input[name=shameMode]:checked').val() === '1';
   var callbackEnd = function(response, responseStatus) {alert("Updating words complete."); };
   $.ajax({
      headers: {"Accept": "application/json", "Authorization": keycloak.token},
      type: "POST",
      url: "shameList",
-     data: JSON.stringify({questions: shameArr}),
+     data: JSON.stringify({questions: shameArr, addToCardbox: addToCardbox}),
      success: callbackEnd,
      error: function(jqXHR, textStatus, errorThrown) { console.log("Error: " + textStatus); }
         });

--- a/frontend/html/styles/styles.css
+++ b/frontend/html/styles/styles.css
@@ -1070,6 +1070,7 @@ color:rgba(213,213,200,1);box-shadow:0px 0px 3px #444,0px 0px 3px #444;vertical-
 .shameList {font-family: 'Montserrat', sans-serif;background-color:rgba(230,230,220,1);resize:none;width:95%!important;outline:none;margin:5px;}
 .shameList:focus {border:1px solid #222;}
 .shameButton {margin:auto;font-family: 'Montserrat', sans-serif;}
+.shameModeWrap {text-align:left;margin:5px;font-family:'Montserrat', sans-serif;font-size:0.85em;}
 
 .animOne {
 	background-color:rgba(140,176,48,1);color:#ddd;


### PR DESCRIPTION
Implements #597.

Adds a radio option to the Cardbox List of Shame UI:
- **Queue new words for later** (default, unchanged behavior) - words not already in cardbox go to `next_added`.
- **Add new words to Cardbox 0 immediately** - words not already in cardbox are inserted straight into cardbox 0 via `_add_word`.

Changes:
- `cardbox/cardbox/views.py`: `shameList` reads an `addToCardbox` flag; when set, new words go to cardbox 0 instead of `next_added`.
- `frontend/html/js/cardboxStats.js`: radio buttons in the List of Shame form; `submitShameList` sends `addToCardbox`.
- `frontend/html/styles/styles.css`: styling for the radio row.

Verified with container builds + endpoint tests inside the cardbox container: existing words are marked wrong in both modes; new words go to `next_added` by default and to cardbox 0 with the flag; duplicates collapse to a single row.