### PR TITLE
fix(cardbox): handle NULL cardbox in /triumphList correct()

### DIFF
--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -297,7 +297,7 @@ def correct(alpha, cardbox=None):
     if cardbox is None:
       g.cur.execute("select cardbox from questions where question=?", (alpha,))
       currentCardbox = g.cur.fetchone()[0]
-      cardbox = currentCardbox + 1
+      cardbox = (currentCardbox or 0) + 1
     g.cur.execute("update questions set cardbox = ?, " +
       "next_scheduled = ?, " +
       "correct=correct+1, streak=streak+1, last_correct = ?, difficulty=4 " +


### PR DESCRIPTION
Fixes #610

`/triumphList` calls `correct()`, which reads the `cardbox` column from `questions`. When the record exists but `cardbox` is NULL, `None + 1` raises a TypeError and returns a 500.

Changes `cardbox/cardbox/views.py` `correct()` so a NULL cardbox is treated as 0 and incremented to 1:

```python
cardbox = (currentCardbox or 0) + 1
```

This also covers the `/correct` endpoint, which shares the same code path.