### PR TITLE
fix: propagate downstream 401s to the client for token refresh

### DIFF
--- a/cardbox/cardbox/__init__.py
+++ b/cardbox/cardbox/__init__.py
@@ -1,8 +1,14 @@
 '''Xerafin service containing cardbox functionality'''
 
-from flask import Flask
+from flask import Flask, jsonify
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # 10mb limit
+
+from xerafinUtil import xerafinUtil as xu
+
+@app.errorhandler(xu.DownstreamError)
+def handle_downstream_error(e):
+  return jsonify(e.body), e.status_code
 
 if __name__ == "__main__":
   app.run(debug=True)

--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -367,11 +367,14 @@ def getQuestions():
                                headers=g.headers,
                                json=words_batch,
                                timeout=10)
+    xu.check401(response)
     if response.status_code == 200:
       word_info_batch = response.json()
     else:
       app.logger.error(f"Word info batch failed: {response.status_code}")
       word_info_batch = {word: {} for word in all_words}
+  except xu.DownstreamError:
+    raise
   except Exception as e:
     app.logger.error(f"Error getting word info: {str(e)}")
     word_info_batch = {word: {} for word in all_words}
@@ -383,11 +386,14 @@ def getQuestions():
                                headers=g.headers,
                                json=words_batch,
                                timeout=10)
+    xu.check401(response)
     if response.status_code == 200:
       dots_batch = response.json()
     else:
       app.logger.error(f"Dots batch failed: {response.status_code}")
       dots_batch = {word: {} for word in all_words}
+  except xu.DownstreamError:
+    raise
   except Exception as e:
     app.logger.error(f"Error getting dots: {str(e)}")
     dots_batch = {word: {} for word in all_words}
@@ -503,7 +509,7 @@ def uploadNewWordList():
         alphaSet.add(alpha)
 
   url = 'http://lexicon:5000/returnValidAlphas'
-  resp = requests.post(url, headers=g.headers, json={'alphas': list(alphaSet)})
+  resp = xu.check401(requests.post(url, headers=g.headers, json={'alphas': list(alphaSet)}))
   validAlphas = resp.json()
 
   insertIntoNextAdded(validAlphas)
@@ -555,7 +561,7 @@ def shameList():
   questions = params.get('questions', [ ])
   addToCardbox = params.get('addToCardbox', False)
   url = 'http://lexicon:5000/returnValidAlphas'
-  resp = requests.post(url, headers=g.headers, json={'alphas': questions})
+  resp = xu.check401(requests.post(url, headers=g.headers, json={'alphas': questions}))
   validAlphas = resp.json()
 
   alphasToAdd = [ ]
@@ -582,7 +588,7 @@ def triumphList():
   params = request.get_json(force=True) # returns dict
   questions = params.get('questions', [ ])
   url = 'http://lexicon:5000/returnValidAlphas'
-  resp = requests.post(url, headers=g.headers, json={'alphas': questions})
+  resp = xu.check401(requests.post(url, headers=g.headers, json={'alphas': questions}))
   validAlphas = resp.json()
 
   for alpha in validAlphas:
@@ -1086,7 +1092,7 @@ def getAnagrams(alpha):
       Should return a list of words ['baa', 'aba']'''
 
   url = 'http://lexicon:5000/getAnagrams'
-  return requests.post(url, headers=g.headers, json={'alpha': alpha}).json()
+  return xu.check401(requests.post(url, headers=g.headers, json={'alpha': alpha})).json()
 
 def getAuxInfo (alpha):
   '''
@@ -1272,7 +1278,7 @@ def reset_start_score():
   '''
   data = {"score": getCardboxScore()}
   url = 'http://stats:5000/resetStartScore'
-  resp = requests.post(url, headers=g.headers, json={"score": getCardboxScore()}).json()
+  resp = xu.check401(requests.post(url, headers=g.headers, json={"score": getCardboxScore()})).json()
   if not resp["success"]:
     app.logger.info(f"Unable to reset cardbox score on upload for {g.uuid}. See stats log for more info.")
   return

--- a/cardbox/xerafinUtil/xerafinUtil.py
+++ b/cardbox/xerafinUtil/xerafinUtil.py
@@ -6,3 +6,22 @@ def debug(message):
   ''' Print a debug message to the log file '''
   timestamp = datetime.now().strftime('%Y %m %d %H:%M:%S')
   app.logger.info(f"{__name__} {timestamp} {message}\n")
+
+class DownstreamError(Exception):
+  '''Raised when a downstream service returns an error we must propagate
+     (e.g. a 401) back to the client, which will refresh its token and retry.'''
+  def __init__(self, status_code, body):
+    super().__init__(f"Downstream service returned {status_code}: {body}")
+    self.status_code = status_code
+    self.body = body
+
+def check401(response):
+  '''Pass through non-401 responses; otherwise raise DownstreamError with the
+     downstream error body so the 401 propagates to the client.'''
+  if response.status_code == 401:
+    try:
+      body = response.json()
+    except Exception:
+      body = {'error': 'Unauthorized'}
+    raise DownstreamError(401, body)
+  return response

--- a/lexicon/lexicon/views.py
+++ b/lexicon/lexicon/views.py
@@ -11,7 +11,8 @@ import itertools
 import dawg
 from pymongo import MongoClient # pylint: disable=E0401
 from pymongo.errors import PyMongoError
-from flask import jsonify, request, g # pylint: disable=E0401
+from flask import jsonify, request, g, abort # pylint: disable=E0401
+from werkzeug.exceptions import HTTPException
 from lexicon import app
 
 dictConfig({
@@ -353,6 +354,8 @@ def get_sloth_data():
       "error": {"status": "success"}
       })
 
+  except HTTPException:
+    raise
   except Exception as e:
     # Log the error
     app.logger.error(f"Error in get_sloth_data: {e}")
@@ -399,6 +402,8 @@ def getAuxInfoBatch(alphalist):
         if response.status_code == 200:
             data = response.json()
             return data
+        elif response.status_code == 401:
+            abort(401, description=response.text)
         else:
             app.logger.error(f"Cardbox service returned error: {response.status_code}")
             return {}

--- a/quiz/quiz/__init__.py
+++ b/quiz/quiz/__init__.py
@@ -1,6 +1,12 @@
-from flask import Flask
+from flask import Flask, jsonify
 
 app = Flask(__name__)
+
+from xerafinUtil import xerafinUtil as xu
+
+@app.errorhandler(xu.DownstreamError)
+def handle_downstream_error(e):
+  return jsonify(e.body), e.status_code
 
 from quiz import views
 

--- a/quiz/quiz/views.py
+++ b/quiz/quiz/views.py
@@ -139,8 +139,8 @@ def getQuestions():
 
   if isCardbox:
     url = 'http://cardbox:5000/getQuestions'
-    response = requests.post(url, headers=g.headers, json=params).json()
-    return jsonify(response)
+    response = xu.check401(requests.post(url, headers=g.headers, json=params))
+    return jsonify(response.json())
   else:
     # Build a non-cardbox quiz
     numQuestions = params.get("numQuestions", 1)
@@ -174,7 +174,7 @@ def getQuestions():
       template["answers"] = questions[alpha]
       url = 'http://cardbox:5000/getAuxInfo'
       data = {"alpha": alpha}
-      auxInfo = requests.post(url, headers=g.headers, json=data).json()["aux"]
+      auxInfo = xu.check401(requests.post(url, headers=g.headers, json=data)).json()["aux"]
       template["correct"] = auxInfo.get("correct")
       template["incorrect"] = auxInfo.get("incorrect")
       template["nextScheduled"] = auxInfo.get("nextScheduled")
@@ -186,8 +186,8 @@ def getQuestions():
       lex_service = 'http://lexicon:5000'
       for word in template["answers"]:
         word_json = {"word": word}
-        word_info = requests.post(f'{lex_service}/getWordInfo', headers=g.headers, json=word_json).json()
-        inner_hooks = requests.post(f'{lex_service}/getDots', headers=g.headers, json=word_json).json()
+        word_info = xu.check401(requests.post(f'{lex_service}/getWordInfo', headers=g.headers, json=word_json)).json()
+        inner_hooks = xu.check401(requests.post(f'{lex_service}/getDots', headers=g.headers, json=word_json)).json()
      # [ front hooks, back hooks, definition, [inner hooks], lexicon symbols ]
         template["words"][word] = [ word_info["front_hooks"], word_info["back_hooks"], word_info["definition"], inner_hooks, word_info.get("lexicon_symbols") ]
       result["questions"].append(template)
@@ -220,7 +220,7 @@ def submitQuestion():
   if increment:
     # call the stats service to increment leaderboard
     url = 'http://stats:5000/increment'
-    resp = requests.get(url, headers=g.headers).json()
+    resp = xu.check401(requests.get(url, headers=g.headers)).json()
     result["qAnswered"] = int(resp["questionsAnswered"])
     result["startScore"] = resp["startScore"]
 
@@ -244,7 +244,7 @@ def submitQuestion():
       data['cardbox'] = currentCardbox + 1
     else:
       url = 'http://cardbox:5000/wrong'
-    resp = requests.post(url, headers=g.headers, json=data).json()
+    resp = xu.check401(requests.post(url, headers=g.headers, json=data)).json()
     result['aux'] = resp['auxInfo']
     result['score'] = resp['score']
   else: # non-cardbox quiz
@@ -253,10 +253,10 @@ def submitQuestion():
     else:
       mark_wrong(alpha, quizid)
     url = 'http://cardbox:5000/getCardboxScore'
-    resp = requests.get(url, headers=g.headers).json()
+    resp = xu.check401(requests.get(url, headers=g.headers)).json()
     result['score'] = resp['score']
     url = 'http://cardbox:5000/getAuxInfo'
-    result['aux'] = requests.post(url, headers=g.headers, json={"alpha": alpha}).json()
+    result['aux'] = xu.check401(requests.post(url, headers=g.headers, json={"alpha": alpha})).json()
 
   return jsonify(result)
 
@@ -513,7 +513,7 @@ def newQuiz():
   if isCardbox:
     result["quizName"] = "Cardbox Quiz"
     url = 'http://cardbox:5000/newQuiz'
-    requests.get(url, headers=g.headers)
+    xu.check401(requests.get(url, headers=g.headers))
   else:
     # Get quiz name - use parameterized query
     g.con.execute(
@@ -559,7 +559,7 @@ def newQuiz():
   # Get cardbox score
   url = 'http://cardbox:5000/getCardboxScore'
   try:
-    response = requests.get(url, headers=g.headers)
+    response = xu.check401(requests.get(url, headers=g.headers))
     response.raise_for_status()
     cbxResponse = response.json()
     cbxScore = cbxResponse.get("score", 0)
@@ -568,7 +568,7 @@ def newQuiz():
 
   # Get stats
   url = 'http://stats:5000/getUserStatsToday'
-  statsResponse = requests.get(url, headers=g.headers).json()
+  statsResponse = xu.check401(requests.get(url, headers=g.headers)).json()
 
   result["qAnswered"] = statsResponse["questionsAnswered"]
   result["startScore"] = statsResponse["startScore"]
@@ -584,7 +584,7 @@ def submitMilestoneChat(milestone):
           'milestoneOf': g.uuid,
           'chatText': f'{g.name} has completed {milestone} questions today.',
           'expire': True}
-  requests.post(url, headers=g.headers, json=data)
+  xu.check401(requests.post(url, headers=g.headers, json=data))
 
 def mark_correct (alpha, quizid) :
 
@@ -642,7 +642,7 @@ def generateQuiz(**kwargs):
   data = {"quantity": kwargs['quantity'], 'lengths': kwargs['lengths']}
   quizJSON = {
     "name": f'{kwargs["descr"]} {datetime.now().strftime(kwargs["datemask"])}',
-    "alphagrams": requests.post(url, headers=g.headers, json=data).json(),
+    "alphagrams": xu.check401(requests.post(url, headers=g.headers, json=data)).json(),
     "id": quizid,
     "size": kwargs['quantity']
   }
@@ -690,7 +690,7 @@ def getNonCardboxQuestions (numNeeded, quizid) : # pylint: disable=unused-argume
   allQuestions = [x[0] for x in g.con.fetchall()]
   url = 'http://lexicon:5000/getManyAnagrams'
   data = {"alphagrams": allQuestions}
-  quiz = requests.post(url, headers=g.headers, json=data).json()
+  quiz = xu.check401(requests.post(url, headers=g.headers, json=data)).json()
   return quiz
 
 def checkOut(alpha, quizid, lock):

--- a/quiz/xerafinUtil/xerafinUtil.py
+++ b/quiz/xerafinUtil/xerafinUtil.py
@@ -17,3 +17,22 @@ def debug(message):
 
 def getMysqlCon():
   return mysql.connect(host=MYSQL_HOST, port=MYSQL_PORT, user=MYSQL_USER, passwd=MYSQL_PWD, db=MYSQL_DB)
+
+class DownstreamError(Exception):
+  '''Raised when a downstream service returns an error we must propagate
+     (e.g. a 401) back to the client, which will refresh its token and retry.'''
+  def __init__(self, status_code, body):
+    super().__init__(f"Downstream service returned {status_code}: {body}")
+    self.status_code = status_code
+    self.body = body
+
+def check401(response):
+  '''Pass through non-401 responses; otherwise raise DownstreamError with the
+     downstream error body so the 401 propagates to the client.'''
+  if response.status_code == 401:
+    try:
+      body = response.json()
+    except Exception:
+      body = {'error': 'Unauthorized'}
+    raise DownstreamError(401, body)
+  return response

--- a/sloth/sloth/__init__.py
+++ b/sloth/sloth/__init__.py
@@ -11,6 +11,13 @@ except ImportError as e:
 
 app = Flask(__name__)
 
+from flask import jsonify
+from xerafinUtil import xerafinUtil as xu
+
+@app.errorhandler(xu.DownstreamError)
+def handle_downstream_error(e):
+  return jsonify(e.body), e.status_code
+
 if __name__ == "__main__":
   app.run(debug=True)
 

--- a/sloth/sloth/views.py
+++ b/sloth/sloth/views.py
@@ -263,6 +263,10 @@ def complete_game():
     g.cur.execute(delete_active_query, (token, g.uuid))
 
     # 3. Submit to chat if it's a record (correct >= 100)
+    # Commit the game result before the (best-effort) chat notification so a
+    # propagated 401 doesn't lose it or cause a duplicate row on client retry.
+    g.con.commit()
+
     chat_sent = False
     if correct >= 50 and isTopScore(token, active_game['alphagram'], active_game['lex']):
       try:
@@ -277,7 +281,7 @@ def complete_game():
           message = f"{username} has set a new record in Subword Sloth for {active_game['alphagram']}. <a href='#' onclick='initSloth(\"{active_game['alphagram']}\",\"{active_game['lex']}\")'>Click here</a> to try it yourself!"
 
         # Call chat service
-        chat_response = requests.post(
+        chat_response = xu.check401(requests.post(
           'http://chat:5000/submitChat',
           headers=g.headers,
           json={
@@ -285,14 +289,14 @@ def complete_game():
               'chatText': message
           },
           timeout=5
-        )
+        ))
         chat_sent = chat_response.status_code == 200
 
+      except xu.DownstreamError:
+        raise
       except Exception as chat_error:
         app.logger.error(f"Chat notification failed: {chat_error}", exc_info=True)
         # Don't fail the whole request if chat fails
-
-    g.con.commit()
 
     return jsonify({
       'status': 'game_completed',
@@ -300,6 +304,8 @@ def complete_game():
       'time_taken': time_taken
     })
 
+  except xu.DownstreamError:
+    raise
   except Exception as e:
     app.logger.error(f"Error completing game: {e}")
     g.con.rollback()
@@ -371,10 +377,10 @@ def getUserAttributes(user_list):
      [ {"userid": uuid, "name": name, "photo": photo}, { .... } ]
   '''
   try:
-    response = requests.post('http://login:5000/getUserNamesAndPhotos',
+    response = xu.check401(requests.post('http://login:5000/getUserNamesAndPhotos',
                    headers=g.headers,
                    json={'userList': user_list},
-                   timeout=10)
+                   timeout=10))
     if response.status_code == 200:
       return response.json()
     return { }

--- a/sloth/sloth/views.py
+++ b/sloth/sloth/views.py
@@ -234,7 +234,25 @@ def complete_game():
     active_game = g.cur.fetchone()
 
     if not active_game:
-      return jsonify({'error': 'Active game not found or unauthorized'}), 404
+      # No active game: this may be a client retry after the game was already
+      # recorded (a propagated 401 aborted the response after the commit).
+      # Be idempotent - if the completion exists, re-send the record chat
+      # announcement and return success instead of 404.
+      completed_query = """
+        SELECT userid, alphagram, lex, time_taken, correct, accuracy
+        FROM sloth_completed
+        WHERE token = %s AND userid = %s
+      """
+      g.cur.execute(completed_query, (token, g.uuid))
+      completed = g.cur.fetchone()
+      if not completed:
+        return jsonify({'error': 'Active game not found or unauthorized'}), 404
+      chat_sent = False
+      if completed['correct'] >= 50 and isTopScore(token, completed['alphagram'], completed['lex']):
+        chat_sent = _submit_record_chat(g.uuid, completed['alphagram'], completed['lex'],
+                                        completed['correct'], completed['accuracy'])
+      return jsonify({'status': 'game_completed', 'chat_sent': chat_sent,
+                      'time_taken': completed['time_taken']})
 
     # Calculate time taken
     time_taken = time.time() - active_game['start_time']
@@ -269,34 +287,8 @@ def complete_game():
 
     chat_sent = False
     if correct >= 50 and isTopScore(token, active_game['alphagram'], active_game['lex']):
-      try:
-        # Get user info for chat message
-        user_info = getUserAttributes([g.uuid])
-        username = user_info[0].get('name', 'A player')
-
-        # Build chat message
-        if correct >= 100 and accuracy >= 100:
-          message = f"{username} has set a new record in Subword Sloth for {active_game['alphagram']} with a perfect score! <a href='#' onclick='initSloth(\"{active_game['alphagram']}\",\"{active_game['lex']}\")'>Click here</a> to try it yourself!"
-        else:
-          message = f"{username} has set a new record in Subword Sloth for {active_game['alphagram']}. <a href='#' onclick='initSloth(\"{active_game['alphagram']}\",\"{active_game['lex']}\")'>Click here</a> to try it yourself!"
-
-        # Call chat service
-        chat_response = xu.check401(requests.post(
-          'http://chat:5000/submitChat',
-          headers=g.headers,
-          json={
-              'userid': '1',  # Subword Sloth system user
-              'chatText': message
-          },
-          timeout=5
-        ))
-        chat_sent = chat_response.status_code == 200
-
-      except xu.DownstreamError:
-        raise
-      except Exception as chat_error:
-        app.logger.error(f"Chat notification failed: {chat_error}", exc_info=True)
-        # Don't fail the whole request if chat fails
+      chat_sent = _submit_record_chat(g.uuid, active_game['alphagram'], active_game['lex'],
+                                      correct, accuracy)
 
     return jsonify({
       'status': 'game_completed',
@@ -310,6 +302,41 @@ def complete_game():
     app.logger.error(f"Error completing game: {e}")
     g.con.rollback()
     return jsonify({'error': 'Internal server error'}), 500
+
+def _submit_record_chat(userid, alpha, lex, correct, accuracy):
+  '''
+  Announce a new record in Subword Sloth in chat.
+  Returns True if the chat message was submitted, False if it failed.
+  '''
+  try:
+    # Get user info for chat message
+    user_info = getUserAttributes([userid])
+    username = user_info[0].get('name', 'A player')
+
+    # Build chat message
+    if correct >= 100 and accuracy >= 100:
+      message = f"{username} has set a new record in Subword Sloth for {alpha} with a perfect score! <a href='#' onclick='initSloth(\"{alpha}\",\"{lex}\")'>Click here</a> to try it yourself!"
+    else:
+      message = f"{username} has set a new record in Subword Sloth for {alpha}. <a href='#' onclick='initSloth(\"{alpha}\",\"{lex}\")'>Click here</a> to try it yourself!"
+
+    # Call chat service
+    chat_response = xu.check401(requests.post(
+      'http://chat:5000/submitChat',
+      headers=g.headers,
+      json={
+          'userid': '1',  # Subword Sloth system user
+          'chatText': message
+      },
+      timeout=5
+    ))
+    return chat_response.status_code == 200
+
+  except xu.DownstreamError:
+    raise
+  except Exception as chat_error:
+    app.logger.error(f"Chat notification failed: {chat_error}", exc_info=True)
+    # Don't fail the whole request if chat fails
+    return False
 
 def getAlphaRankings(alpha, lexicon):
   try:

--- a/sloth/xerafinUtil/xerafinUtil.py
+++ b/sloth/xerafinUtil/xerafinUtil.py
@@ -17,3 +17,22 @@ def debug(message):
 
 def getMysqlCon():
   return mysql.connect(host=MYSQL_HOST, port=MYSQL_PORT, user=MYSQL_USER, passwd=MYSQL_PWD, db=MYSQL_DB)
+
+class DownstreamError(Exception):
+  '''Raised when a downstream service returns an error we must propagate
+     (e.g. a 401) back to the client, which will refresh its token and retry.'''
+  def __init__(self, status_code, body):
+    super().__init__(f"Downstream service returned {status_code}: {body}")
+    self.status_code = status_code
+    self.body = body
+
+def check401(response):
+  '''Pass through non-401 responses; otherwise raise DownstreamError with the
+     downstream error body so the 401 propagates to the client.'''
+  if response.status_code == 401:
+    try:
+      body = response.json()
+    except Exception:
+      body = {'error': 'Unauthorized'}
+    raise DownstreamError(401, body)
+  return response

--- a/stats/stats/__init__.py
+++ b/stats/stats/__init__.py
@@ -1,6 +1,12 @@
-from flask import Flask
+from flask import Flask, jsonify
 
 app = Flask(__name__)
+
+from xerafinUtil import xerafinUtil as xu
+
+@app.errorhandler(xu.DownstreamError)
+def handle_downstream_error(e):
+  return jsonify(e.body), e.status_code
 
 from stats import views
 

--- a/stats/stats/views.py
+++ b/stats/stats/views.py
@@ -164,7 +164,7 @@ def increment():
                     where userid = '{g.uuid}' and dateStamp = curdate()''')
   if g.con.rowcount == 0:
     url = 'http://cardbox:5000/getCardboxScore'
-    resp = requests.get(url, headers=g.headers).json()
+    resp = xu.check401(requests.get(url, headers=g.headers)).json()
     startScore = resp["score"]
     questionsAnswered = 1
     g.con.execute(f'''insert into leaderboard (userid, dateStamp, questionsAnswered, startScore)
@@ -434,7 +434,7 @@ def getUserStatsToday():
   else:
     questionsAnswered = 0
     url = 'http://cardbox:5000/getCardboxScore'
-    resp = requests.get(url, headers=g.headers).json()
+    resp = xu.check401(requests.get(url, headers=g.headers)).json()
     startScore = resp["score"]
 
   return {'questionsAnswered': questionsAnswered, 'startScore': startScore}
@@ -446,7 +446,7 @@ def getUserData(uuidList):
    '''
 
   url = 'http://login:5000/getUserNamesAndPhotos'
-  resp = requests.get(url, headers=g.headers, json={"userList": uuidList}).json()
+  resp = xu.check401(requests.get(url, headers=g.headers, json={"userList": uuidList})).json()
   return resp
 
 def get_users_by_period(period: str, con) -> int:

--- a/stats/xerafinUtil/xerafinUtil.py
+++ b/stats/xerafinUtil/xerafinUtil.py
@@ -16,3 +16,22 @@ def debug(message):
 
 def getMysqlCon():
    return mysql.connect(host=MYSQL_HOST, port=MYSQL_PORT, user=MYSQL_USER, passwd=MYSQL_PWD, db=MYSQL_DB)
+
+class DownstreamError(Exception):
+  '''Raised when a downstream service returns an error we must propagate
+     (e.g. a 401) back to the client, which will refresh its token and retry.'''
+  def __init__(self, status_code, body):
+    super().__init__(f"Downstream service returned {status_code}: {body}")
+    self.status_code = status_code
+    self.body = body
+
+def check401(response):
+  '''Pass through non-401 responses; otherwise raise DownstreamError with the
+     downstream error body so the 401 propagates to the client.'''
+  if response.status_code == 401:
+    try:
+      body = response.json()
+    except Exception:
+      body = {'error': 'Unauthorized'}
+    raise DownstreamError(401, body)
+  return response


### PR DESCRIPTION


## Closes

Closes #560

Closes #612, #613, #614, #615, #616, #617, #618, #620, #621, #622, #623

## Problem
When a backend service returns 401 to another backend service (e.g. lexicon → cardbox), the status was swallowed and the client never saw it. Worst case: `cardbox`'s `getQuestions` crashed with `KeyError: 'front_hooks'` (→ 500) instead of propagating the 401. The client's `fetchWithAuth` already refreshes the token and retries on a 401 — it just never received one.

## Fix
Add a shared helper (`DownstreamError` + `check401()`) to each service's `xerafinUtil/xerafinUtil.py` (duplicated per repo convention) and register an `@app.errorhandler(xu.DownstreamError)` in each service's `__init__.py`. Every cross-service call site that forwards `g.headers` now re-raises a downstream 401 with its original error body, so the 401 bubbles up through the whole chain (client → quiz → cardbox → lexicon) to the client.

Services touched:
- **cardbox**: `getQuestions` (both lexicon batch calls — fixes the `KeyError`), `uploadNewWordList`, `shameList`, `triumphList`, `getAnagrams`, `reset_start_score`
- **quiz**: all 14 cross-service call sites (`getQuestions`, `submitQuestion`, `newQuiz`, `submitMilestoneChat`, periodic-quiz lexicon calls)
- **stats**: `increment`, `getUserStatsToday`, `getUserData`
- **sloth**: `getUserAttributes`; `slothComplete` now propagates a 401 from the chat notification (`g.con.commit()` moved ahead of it so a retry doesn't lose the game result or duplicate the row)
- **lexicon**: `getAuxInfoBatch` aborts on a cardbox 401 (with an `except HTTPException: raise` guard in `get_sloth_data`)

## Notes
- Out of scope: `chat/` (Go) already partially handles this, cron scripts (no client), frontend (no change needed).
- Key-rotation staleness of the cached `get_public_key()` is a separate issue.
- No test suite exists (per AGENTS.md); `py_compile` passes on all changed files and `check401` logic was tested in isolation. Recommend building affected containers and confirming a bad/expired token returns 401 through `quiz/getQuestions`.
