### PR TITLE
feat(quiz): per-quiz and bulk progress reset for overview search (#338)

### DIFF
--- a/frontend/html/js/frag.overviewSearch.js
+++ b/frontend/html/js/frag.overviewSearch.js
@@ -10,6 +10,7 @@ OverviewSearch.prototype = {
 		this.drawSearchRows();
 		$(this.cont).append(this.getTypeOption(),this.params);
 		$(this.cont).append(this.addSearchButton());
+		$(this.cont).append(this.addResetResultsButton());
 	},
 
 //---------------------------------------------------------------------
@@ -115,6 +116,34 @@ OverviewSearch.prototype = {
 		});
 		$(this.searchRow).append(this.searchButton);
 		return this.searchRow;
+	},
+
+//---------------------------------------------------------------------
+
+	addResetResultsButton: function() {
+		let self=this;
+		this.resetResultsButton = document.createElement('button');
+		$(this.resetResultsButton).addClass('overviewButton');
+		$(this.resetResultsButton).html('↻ Reset All Results');
+		$(this.resetResultsButton).prop('disabled',true);
+		$(this.resetResultsButton).attr('title','Resets all progress for every quiz in the current search results.');
+		$(this.resetResultsButton).css({'margin':'auto!important'});
+		$(this.resetResultsButton).on('click',function(){
+			self.action('SEARCH_RESET_RESULTS');
+		});
+		this.resetResultsRow = document.createElement('div');
+		$(this.resetResultsRow).addClass('overviewQueryRow');
+		$(this.resetResultsRow).css({'padding-top':'2px','padding-bottom':'2px','text-align':'center'});
+		$(this.resetResultsRow).append(this.resetResultsButton);
+		return this.resetResultsRow;
+	},
+
+//---------------------------------------------------------------------
+
+	setResetState:function(count){
+		if (typeof this.resetResultsButton!=='undefined'){
+			$(this.resetResultsButton).prop('disabled', Number(count)===0);
+		}
 	},
 
 //---------------------------------------------------------------------

--- a/frontend/html/js/quiz.js
+++ b/frontend/html/js/quiz.js
@@ -49,7 +49,7 @@ class QuizList {
     $.ajax({type: "POST",
             data: JSON.stringify(d),
             headers: {"Accept": "application/json", "Authorization": keycloak.token},
-            url: "discardBookmark.py",
+            url: "discardBookmark",
             success: function(response, responseStatus) { self.refreshQuizList(self.data); },
             error: function(jqXHR, textStatus, errorThrown) {
                  var msg = "error, status = " + textStatus + " error: " + errorThrown;
@@ -66,8 +66,25 @@ class QuizList {
     $.ajax({type: "POST",
             data: JSON.stringify(d),
             headers: {"Accept": "application/json", "Authorization": keycloak.token},
-            url: "resetQuiz.py",
+            url: "resetQuiz",
             success: function(response, responseStatus) { //console.log("Quiz reset");
+                                                          self.refreshQuizList(self.data);
+                              },
+            error: function(jqHXR, textStatus, errorThrown) {
+                 var msg = "error, status = " + textStatus + " error: " + errorThrown;
+                 appendDebugLog(msg); }
+          });
+    }
+
+  resetQuizList(query, action) {
+    var self = this;
+    self.initialized = false;
+    var d = Object.assign({}, query, {action: action});
+    $.ajax({type: "POST",
+            data: JSON.stringify(d),
+            headers: {"Accept": "application/json", "Authorization": keycloak.token},
+            url: "resetQuizList",
+            success: function(response, responseStatus) {
                                                           self.refreshQuizList(self.data);
                               },
             error: function(jqHXR, textStatus, errorThrown) {

--- a/frontend/html/js/xeraUI.js
+++ b/frontend/html/js/xeraUI.js
@@ -64,6 +64,7 @@ XeraOverviewManager.prototype = {
     overviewAH.add('SEARCH_SELECTION',{'action': "overview.searchSelectionList",'watch':true});
     overviewAH.add('SEARCH_SET_GO_NAME',{'action': "overview.searchSetGoName",'watch':true});
     overviewAH.add('SEARCH_ADD',{'action': "overview.searchAdd",'watch':true});
+    overviewAH.add('SEARCH_RESET_RESULTS',{'action': "overview.resetSearchResults",'watch':true});
 
   //Any Go Action:  Context passed into function
     overviewAH.add('SET_GO_ACTION',{'action': "overview.setGoAction",'watch':true});
@@ -217,6 +218,7 @@ XeraOverviewManager.prototype = {
       ["SEARCH_TOGGLE_SEARCH", {'action': "overviewUI.childUI['overviewSearch'].toggleSearch", 'watch':true}],
       ["SEARCH_CLEAR_SELECTION", {'action': "overviewUI.childUI['searchList'].clearSelection", 'watch':true}],
       ["SEARCH_EMPTY", {'action': "overviewUI.childUI['searchList'].clearAll", 'watch':true}],
+      ["SEARCH_SET_RESET_STATE", {'action': "overviewUI.childUI['overviewSearch'].setResetState", 'watch':true}],
 
     ]);
   },
@@ -481,6 +483,7 @@ XeraOverviewManager.prototype = {
       });
       overviewUI.update("SEARCH_CLEAR_SELECTION");
       overviewUI.update("SEARCH_EMPTY");
+      overviewUI.update("SEARCH_SET_RESET_STATE",0);
     }
     this.data.lexicon.initialized = true;
     //do a redraw of quizlists
@@ -492,6 +495,7 @@ XeraOverviewManager.prototype = {
     this.setGoButtons(false);
     this.resetWritePoll(function(){
       self.fetchData();
+      self.refreshSearchResults();
     });
   },
   resetWrong:function(x){
@@ -501,7 +505,32 @@ XeraOverviewManager.prototype = {
     this.setGoButtons(false);
     this.resetWritePoll(function(){
       self.fetchData();
+      self.refreshSearchResults();
     });
+  },
+  refreshSearchResults:function(){
+    if (typeof this.data.searchQuery!=='undefined'){
+      this.data.searchList.refreshQuizList(this.data.searchQuery);
+      this.data.searchList.fetched = false;
+      this.fetchQuizList('SRH');
+    }
+  },
+  resetSearchResults:function(){
+    let self=this;
+    if (typeof this.data.searchQuery==='undefined'){
+      return;
+    }
+    let count = Object.keys(this.data.searchList.quizList).length;
+    if (confirm("This will reset all progress for every quiz in the current search results ("+count+" quiz"+(count===1 ? "" : "zes")+"). Continue?")){
+      this.setGoButtons(false);
+      this.data.writeList.resetQuizList(this.data.searchQuery, "resetall");
+      this.data.writeList.fetched = false;
+      this.resetWritePoll(function(){
+        self.fetchData();
+        self.refreshSearchResults();
+        self.setGoButtons(true);
+      });
+    }
   },
   discard:function(x){
     let self=this;
@@ -562,6 +591,7 @@ XeraOverviewManager.prototype = {
     d.lexicon = this.data.lexicon.lexicon;
     d.version = this.data.lexicon.version;
     xerafin.error.log.add(d,'JSON');
+    this.data.searchQuery = d;
     this.data.searchList.refreshQuizList(d);
     this.data.searchList.fetched = false;
     this.fetchQuizList('SRH');
@@ -631,6 +661,7 @@ XeraOverviewManager.prototype = {
       if (obj==='searchList'){
         overviewUI.update('LST_UPD_SRH',this.data.searchList.quizList);
         overviewUI.update('SEARCH_TOGGLE_SEARCH',true);
+        overviewUI.update('SEARCH_SET_RESET_STATE',Object.keys(this.data.searchList.quizList).length);
       }
       overviewUI.update('LST_UPD_'+type,this.data[obj].quizList);
       this.setMySelectionRow([this.data.currentQuiz]);

--- a/frontend/locations.conf
+++ b/frontend/locations.conf
@@ -139,6 +139,15 @@
 	location /subscribe {
 		proxy_pass http://quiz:5000/subscribe;
 	}
+	location /resetQuiz {
+		proxy_pass http://quiz:5000/resetQuiz;
+	}
+	location /resetQuizList {
+		proxy_pass http://quiz:5000/resetQuizList;
+	}
+	location /discardBookmark {
+		proxy_pass http://quiz:5000/discardBookmark;
+	}
 
         # x-lexicon service endpoints
         #

--- a/quiz/quiz/views.py
+++ b/quiz/quiz/views.py
@@ -260,12 +260,10 @@ def submitQuestion():
 
   return jsonify(result)
 
-@app.route("/getQuizList", methods=["GET", "POST"])
-def getQuizList():
-  '''Returns a dict where the quizid is the keys'''
-  params = request.get_json(force=True) # returns a dict
-  result = { }
-
+def buildQuizIdList(params):
+  '''Builds the list of quiz ids matching the given search parameters.
+  Shared by getQuizList and resetQuizList so bulk resets match the
+  search results exactly.'''
   QUIZ_INACTIVE_TIMER = 4 # how many days before inactive quizzes drop off the list
   QUIZ_TYPE_NEW = 2
   QUIZ_TYPE_VOWEL = 5
@@ -368,9 +366,16 @@ def getQuizList():
   else:
     quizidList = [ ]
 
-  # we have a list of quizids to return. Get the metadata and status
+  return quizidList[:50] # hard limit of 50 results
 
-  quizidList = quizidList[:50] # hard limit of 50 results
+@app.route("/getQuizList", methods=["GET", "POST"])
+def getQuizList():
+  '''Returns a dict where the quizid is the keys'''
+  params = request.get_json(force=True) # returns a dict
+  result = { }
+
+  # Supported search types - myQuizzes, daily, quizid, completed
+  quizidList = buildQuizIdList(params)
 
   # Batch fetch all data to avoid N+1 queries
   quiz_metadata = {}
@@ -427,11 +432,6 @@ def getQuizList():
         template["untried"] = template["quizsize"] - int(sum_completed)
         if template["untried"] == 0:
           template["status"] = "Completed"
-          if max_last_answered:
-            lastCorrect = max_last_answered
-            # if it's completed more than four days ago, drop it off the list entirely
-            if (datetime.today() - lastCorrect).days > QUIZ_INACTIVE_TIMER:
-              continue
         else:
           template["status"] = "Active"
 
@@ -440,11 +440,61 @@ def getQuizList():
         template["incorrect"] = int(sum_completed) - int(sum_correct)
 
       template["bookmarked"] = qid in bookmarked_set
-      template["sub"] = (searchType == "myQuizzes" and qid != -1 and not template["bookmarked"] )
+      template["sub"] = (params.get('searchType') == "myQuizzes" and qid != -1 and not template["bookmarked"] )
 
       result[index] = template
 
   return jsonify(result)
+
+@app.route("/resetQuiz", methods=["POST"])
+def resetQuiz():
+  '''Resets progress for a single quiz for the current user.'''
+  params = request.get_json(force=True) # returns a dict
+  quizid = params.get('quizid', params.get('quiz'))
+  action = params.get('action', 'resetall')
+
+  if action not in ("resetall", "resetwrong"):
+    return jsonify({'error': 'invalid action'}), 400
+
+  if action == "resetall":
+    g.con.execute("update quiz_user_detail set locked=0, completed=0, correct=0, "
+        + "incorrect=0, last_answered=NULL where quiz_id=%s and user_id=%s", (quizid, g.uuid))
+  else:
+    g.con.execute("update quiz_user_detail set locked=0, completed=0, correct=0, "
+        + "incorrect=0, last_answered=NULL where quiz_id=%s and user_id=%s and incorrect=1",
+        (quizid, g.uuid))
+
+  return jsonify({'reset': quizid, 'action': action})
+
+@app.route("/resetQuizList", methods=["POST"])
+def resetQuizList():
+  '''Resets progress for every quiz matching the given search parameters.
+  Mirrors getQuizList so the reset exactly covers the current search results.'''
+  params = request.get_json(force=True) # returns a dict
+  action = params.get('action', 'resetall')
+
+  quizidList = [qid for qid in buildQuizIdList(params) if qid != -1]
+
+  if not quizidList:
+    return jsonify({'count': 0, 'quizids': []})
+
+  placeholders = ','.join(['%s'] * len(quizidList))
+  g.con.execute("update quiz_user_detail set locked=0, completed=0, correct=0, "
+      + "incorrect=0, last_answered=NULL where user_id=%s and quiz_id in (" + placeholders + ")",
+      [g.uuid] + quizidList)
+
+  return jsonify({'count': len(quizidList), 'quizids': quizidList})
+
+@app.route("/discardBookmark", methods=["POST"])
+def discardBookmark():
+  '''Removes the quiz (and its progress) from the current user's quizzes.'''
+  params = request.get_json(force=True) # returns a dict
+  quizid = params.get('quizid')
+
+  g.con.execute("delete from quiz_user_detail where quiz_id=%s and user_id=%s", (quizid, g.uuid))
+  g.con.execute("delete from user_quiz_bookmark where quiz_id=%s and user_id=%s", (quizid, g.uuid))
+
+  return jsonify({'discarded': quizid})
 
 @app.route("/subscribe", methods=["POST"])
 def subscribe():


### PR DESCRIPTION
Closes #338

## Problem
Overview/Search lets users find canned quizzes and tracks progress, but there was no working way to reset progress to replay a quiz:
- The Reset All / Reset Wrong / Discard buttons posted to `resetQuiz.py` / `discardBookmark.py`, which don't exist in v3 (no Flask route, no nginx location) — they 404'd.
- Completed quizzes were silently dropped from all search results 4 days after completion, so they became unfindable.
- A fully completed quiz could never be replayed anyway: `getNonCardboxQuestions` only serves `completed = 0` rows.

## Changes
### Backend (`quiz/quiz/views.py`)
- Removed the 4-day drop so completed quizzes remain in search results for all search types; the "Recently Completed" My-Quizzes list keeps its 4-day window.
- Extracted the search-type switch into a shared `buildQuizIdList()` helper so bulk resets match search results exactly (including the 50-result cap).
- New endpoints (all scoped to the JWT user):
  - `POST /resetQuiz` — `{quizid, action}` with `resetall` (zero all progress in place) or `resetwrong` (clear only incorrect answers).
  - `POST /resetQuizList` — same params as `getQuizList` + `action`; bulk-resets every quiz in the current search results; cardbox (`-1`) excluded.
  - `POST /discardBookmark` — removes the quiz's progress rows and bookmark.

### Frontend
- `quiz.js`: `resetQuiz()`/`discardBookmark()` now target the Flask endpoints; added `resetQuizList()`.
- `xeraUI.js`: persists the last search query, adds the `SEARCH_RESET_RESULTS` action, refreshes search results after any reset, and drives the reset-button enabled state.
- `frag.overviewSearch.js`: added a "↻ Reset All Results" button to the Search tab — always visible but disabled until a search returns results.

### nginx
- `frontend/locations.conf`: proxy `/resetQuiz`, `/resetQuizList`, `/discardBookmark` to the quiz service.

## Verification
Built `x-quiz`/`x-frontend` images, restarted `xerafin.target`, and exercised every endpoint against the running stack via a throwaway Keycloak user (created, tested, and deleted):
- A quiz fully completed in 2019 now appears as `status: Completed` in search results; `completed` search type still respects the 4-day window.
- `resetQuiz` resetall zeros rows (Completed → Active); resetwrong clears only incorrect rows.
- `resetQuizList` reset exactly the 14 vowel-search results and left an unrelated in-progress quiz untouched.
- `discardBookmark` removes progress + bookmark; `myQuizzes` bulk reset skips the `-1` cardbox entry.