### PR TITLE
fix(cardbox): initialize cardbox schema before index creation (#634)

### DIFF
--- a/cardbox/cardbox/views.py
+++ b/cardbox/cardbox/views.py
@@ -152,21 +152,6 @@ def _lookahead_seconds_case():
                    for cb in range(0, 13))
   return f"CASE cardbox {parts} ELSE {top} END"
 
-def _ensure_indexes():
-  ''' Create the indexes the hot queries depend on, if missing.
-      Guarded by PRAGMA index_list so the common case is a cheap read-only
-      check (no per-request schema write lock). '''
-  g.cur.execute("pragma index_list('questions')")
-  existing = {row[1] for row in g.cur.fetchall()}
-  stmts = {
-    'idx_q_cardbox_sched': "create index idx_q_cardbox_sched on questions(cardbox, next_scheduled)",
-    'idx_q_diff_sched': "create index idx_q_diff_sched on questions(difficulty, next_scheduled)",
-    'idx_q_next_sched': "create index idx_q_next_sched on questions(next_scheduled, cardbox)",
-  }
-  for name, stmt in stmts.items():
-    if name not in existing:
-      g.cur.execute(stmt)
-
 @app.before_request
 def get_user():
   # Skip verification for public routes
@@ -204,7 +189,8 @@ def get_user():
     g.con.execute("PRAGMA busy_timeout=5000")
     g.con.execute("PRAGMA synchronous=NORMAL")
     g.cur = g.con.cursor()
-    _ensure_indexes()
+    if not checkCardboxDatabase():
+      raise RuntimeError("cardbox database could not be initialized")
     # Debug for slow queries
     g.start_time = time.time()
 
@@ -1257,6 +1243,19 @@ def checkCardboxDatabase ():
         g.cur.execute("create table next_Added (question varchar(16), timeStamp integer)")
       g.cur.execute("create unique index if not exists question_index on questions(question)")
       g.cur.execute("create unique index if not exists next_added_question_idx on next_added(question)")
+      # Create the indexes the hot queries depend on, if missing. Guarded by
+      # PRAGMA index_list so the common case is a cheap read-only check (no
+      # per-request schema write lock).
+      g.cur.execute("pragma index_list('questions')")
+      existing = {row[1] for row in g.cur.fetchall()}
+      stmts = {
+        'idx_q_cardbox_sched': "create index idx_q_cardbox_sched on questions(cardbox, next_scheduled)",
+        'idx_q_diff_sched': "create index idx_q_diff_sched on questions(difficulty, next_scheduled)",
+        'idx_q_next_sched': "create index idx_q_next_sched on questions(next_scheduled, cardbox)",
+      }
+      for name, stmt in stmts.items():
+        if name not in existing:
+          g.cur.execute(stmt)
 
       g.cur.execute("select * from cleared_until")
       row = g.cur.fetchone()


### PR DESCRIPTION
## Summary

Fixes #634 — brand-new users were left with an empty cardbox `.db` (no tables), which caused downstream failures in the quiz service (`newQuiz`).

### Root cause

Commit `bd73447` added `_ensure_indexes()`, called from the cardbox service's `before_request` hook. On a brand-new user's first request (`initCardbox` on login), `lite.connect()` creates an empty `.db`, then `_ensure_indexes()` tried `create index ... on questions(...)` before the `questions` table existed. That raised `sqlite3.OperationalError: no such table`, was swallowed by the broad `except Exception` in `get_user()`, and returned **401** — so `checkCardboxDatabase()` (which creates the tables) inside `/initCardbox` never ran, and the file stayed permanently empty.

### Fix

- Deleted `_ensure_indexes()`.
- Folded its three index creations into `checkCardboxDatabase()` (same `pragma index_list` guard, so the hot path stays a cheap read-only check), placed after table creation so `questions` always exists.
- `get_user()` (`before_request`) now calls `checkCardboxDatabase()` and raises if it fails, so a new user's `.db` is initialized (tables + indexes) before anything else runs.

The cardbox service is now self-healing on every request, matching the intended behavior described in #634 ("create a properly formatted .db with empty tables").

### Verification

- `podman build -t x-cardbox:latest cardbox` builds clean.
- Ran the real `checkCardboxDatabase()` inside the image against a fresh DB: returns `True`, creates `questions`, `cleared_until`, `new_words_at`, `next_Added` plus all five indexes, and is idempotent on repeat calls.

### Notes

- `quiz/views.py:573` guard from the issue's suggested fix is intentionally **not** included (per scope decision); this PR fixes the root cause in cardbox init.
- Legacy `checkCardboxDatabase` copies in `xerafinLib/xerafinLib.py` and `cardbox/cardbox/xerafinLib.py` left untouched (not on the request path).